### PR TITLE
Add AutoM8 logo and mascot assets

### DIFF
--- a/site/src/layouts/BaseLayout.astro
+++ b/site/src/layouts/BaseLayout.astro
@@ -25,6 +25,7 @@ const nav = [
     <meta name="description" content={description} />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" content="#0B1220" />
+    <link rel="icon" type="image/svg+xml" href="/branding/favicon.svg" />
     <meta property="og:title" content={title} />
     <meta property="og:description" content={description} />
     <meta property="og:type" content="website" />
@@ -35,17 +36,11 @@ const nav = [
     <header class="sticky top-0 z-40 border-b border-slate-800/80 bg-slate-950/80 backdrop-blur-xl">
       <div class="mx-auto flex max-w-7xl items-center justify-between px-6 py-4">
         <a href="/" class="group flex items-center gap-3" aria-label="AutoM8">
-          <div class="brand-mark" aria-hidden="true">
-            <span class="brand-mark__eyes">&gt;_</span>
-            <span class="brand-mark__eight">8</span>
-          </div>
-
-          <div>
-            <div class="text-lg font-black tracking-tight text-white">
-              Auto<span class="text-blue-400">M8</span>
-            </div>
-            <div class="text-xs font-medium text-slate-400">by OSLabs</div>
-          </div>
+          <img
+            src="/branding/logo-autom8-horizontal.svg"
+            alt="AutoM8 by OSLabs"
+            class="h-12 w-auto max-w-[220px]"
+          />
         </a>
 
         <nav class="hidden items-center gap-5 text-sm font-semibold text-slate-300 lg:flex">

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -72,12 +72,12 @@ const trustItems = [
       </div>
 
       <div class="autom8-card m8-mascot rounded-3xl p-6">
-        <div class="m8-robot" aria-label="Mascote M8">
-          <div class="m8-robot__antenna"></div>
-          <div class="m8-robot__head">
-            <div class="m8-robot__visor">&gt;_</div>
-          </div>
-          <div class="m8-robot__body">8</div>
+        <div class="relative z-10 flex items-center justify-center">
+          <img
+            src="/branding/mascot-m8.svg"
+            alt="Mascote M8 do AutoM8"
+            class="mx-auto h-auto w-full max-w-sm"
+          />
         </div>
 
         <div class="m8-bubble">
@@ -218,6 +218,11 @@ const trustItems = [
         </div>
 
         <div class="rounded-2xl border border-slate-700 bg-slate-950/50 p-6">
+          <img
+            src="/branding/logo-autom8-icon.svg"
+            alt="Ícone AutoM8"
+            class="mb-4 h-12 w-12"
+          />
           <p class="font-mono text-sm text-green-300">AutoM8 by OSLabs</p>
           <p class="mt-3 text-2xl font-black text-white">Automação Linux para todos.</p>
           <p class="mt-3 leading-7 text-slate-400">Configure menos. Produza mais.</p>


### PR DESCRIPTION
Adiciona os ativos visuais oficiais iniciais do AutoM8 em SVG, incluindo logo horizontal, ícone, favicon e mascote M8, aplicando-os no header, hero e bloco de autoria sem alterar menus ou rotas.