### PR TITLE
Add missing AutoM8 branding SVG assets

### DIFF
--- a/site/public/branding/favicon.svg
+++ b/site/public/branding/favicon.svg
@@ -1,0 +1,8 @@
+<svg width="512" height="512" viewBox="0 0 512 512" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="512" height="512" rx="128" fill="#0B1220"/>
+  <rect x="56" y="56" width="400" height="400" rx="104" fill="#0F172A" stroke="#38BDF8" stroke-width="12"/>
+  <rect x="108" y="148" width="296" height="154" rx="48" fill="#020617" stroke="#2563EB" stroke-width="10"/>
+  <text x="256" y="248" text-anchor="middle" font-family="JetBrains Mono, Fira Code, Consolas, monospace" font-size="78" font-weight="900" fill="#22C55E">&gt;_</text>
+  <text x="256" y="392" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="132" font-weight="950" fill="#38BDF8">8</text>
+  <circle cx="396" cy="116" r="18" fill="#22C55E"/>
+</svg>

--- a/site/public/branding/logo-autom8-horizontal.svg
+++ b/site/public/branding/logo-autom8-horizontal.svg
@@ -1,0 +1,15 @@
+<svg width="760" height="180" viewBox="0 0 760 180" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="760" height="180" rx="36" fill="none"/>
+  <g>
+    <rect x="18" y="22" width="136" height="136" rx="36" fill="#0F172A" stroke="#38BDF8" stroke-width="5"/>
+    <rect x="42" y="54" width="88" height="50" rx="16" fill="#020617" stroke="#2563EB" stroke-width="4"/>
+    <text x="86" y="88" text-anchor="middle" font-family="JetBrains Mono, Fira Code, Consolas, monospace" font-size="28" font-weight="900" fill="#22C55E">&gt;_</text>
+    <text x="86" y="143" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="58" font-weight="950" fill="#38BDF8">8</text>
+    <circle cx="132" cy="43" r="8" fill="#22C55E"/>
+  </g>
+
+  <text x="184" y="93" font-family="Inter, Arial, sans-serif" font-size="62" font-weight="950" fill="#F8FAFC">Auto</text>
+  <text x="330" y="93" font-family="Inter, Arial, sans-serif" font-size="62" font-weight="950" fill="#38BDF8">M8</text>
+  <text x="186" y="132" font-family="Inter, Arial, sans-serif" font-size="22" font-weight="700" fill="#94A3B8">by OSLabs</text>
+  <text x="186" y="158" font-family="JetBrains Mono, Fira Code, Consolas, monospace" font-size="16" font-weight="700" fill="#22C55E">Linux automation for everyone</text>
+</svg>

--- a/site/public/branding/logo-autom8-icon.svg
+++ b/site/public/branding/logo-autom8-icon.svg
@@ -1,0 +1,8 @@
+<svg width="512" height="512" viewBox="0 0 512 512" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="512" height="512" rx="128" fill="#0B1220"/>
+  <rect x="56" y="56" width="400" height="400" rx="104" fill="#0F172A" stroke="#38BDF8" stroke-width="12"/>
+  <rect x="108" y="148" width="296" height="154" rx="48" fill="#020617" stroke="#2563EB" stroke-width="10"/>
+  <text x="256" y="248" text-anchor="middle" font-family="JetBrains Mono, Fira Code, Consolas, monospace" font-size="78" font-weight="900" fill="#22C55E">&gt;_</text>
+  <text x="256" y="392" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="132" font-weight="950" fill="#38BDF8">8</text>
+  <circle cx="396" cy="116" r="18" fill="#22C55E"/>
+</svg>

--- a/site/public/branding/mascot-m8.svg
+++ b/site/public/branding/mascot-m8.svg
@@ -1,0 +1,24 @@
+<svg width="620" height="620" viewBox="0 0 620 620" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="310" cy="310" r="248" fill="#2563EB" opacity="0.10"/>
+  <circle cx="310" cy="310" r="194" fill="#38BDF8" opacity="0.08"/>
+
+  <rect x="294" y="58" width="32" height="74" rx="16" fill="#94A3B8"/>
+  <circle cx="310" cy="50" r="24" fill="#38BDF8"/>
+  <circle cx="310" cy="50" r="42" fill="#38BDF8" opacity="0.16"/>
+
+  <rect x="122" y="132" width="376" height="258" rx="84" fill="#E2E8F0" stroke="#F8FAFC" stroke-width="10"/>
+  <rect x="156" y="172" width="308" height="146" rx="44" fill="#020617" stroke="#2563EB" stroke-width="8"/>
+  <text x="310" y="270" text-anchor="middle" font-family="JetBrains Mono, Fira Code, Consolas, monospace" font-size="86" font-weight="900" fill="#22C55E">&gt;_</text>
+
+  <rect x="76" y="222" width="54" height="92" rx="27" fill="#BFDBFE" stroke="#2563EB" stroke-width="6"/>
+  <rect x="490" y="222" width="54" height="92" rx="27" fill="#BFDBFE" stroke="#2563EB" stroke-width="6"/>
+
+  <rect x="190" y="372" width="240" height="162" rx="58" fill="#2563EB" stroke="#38BDF8" stroke-width="8"/>
+  <text x="310" y="492" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="138" font-weight="950" fill="#0B1220">8</text>
+
+  <path d="M190 432C142 440 112 468 98 516" stroke="#38BDF8" stroke-width="18" stroke-linecap="round"/>
+  <path d="M430 432C478 440 508 468 522 516" stroke="#38BDF8" stroke-width="18" stroke-linecap="round"/>
+
+  <circle cx="100" cy="522" r="26" fill="#22C55E"/>
+  <circle cx="520" cy="522" r="26" fill="#22C55E"/>
+</svg>


### PR DESCRIPTION
Adiciona os arquivos SVG de branding que já são referenciados pela landing page: logo horizontal, ícone, favicon e mascote M8.