### PR TITLE
Replace home info sections with carousel

### DIFF
--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -96,13 +96,14 @@ const carouselItems = [
     type: 'text',
     icon: '03'
   },
-  ...distros.map((distro) => ({
+  {
     eyebrow: 'Compatibilidade',
-    title: distro.name,
-    description: 'Planejada',
-    type: 'distro',
-    icon: distro.slug
-  }))
+    title: '',
+    description: '',
+    type: 'distroGroup',
+    icon: 'distros',
+    distros
+  }
 ];
 
 
@@ -187,12 +188,8 @@ const moduleIcons = {
         {carouselItems.map((item) => (
           <article class="home-carousel-card">
             <div class="home-carousel-card__top">
-              {item.type === 'distro' ? (
-                <img
-                  src={`/branding/distros/${item.icon}.svg`}
-                  alt={`Ícone ${item.title}`}
-                  class="home-carousel-card__distro-icon"
-                />
+              {item.type === 'distroGroup' ? (
+                <span class="home-carousel-card__number">OS</span>
               ) : (
                 <span class="home-carousel-card__number">{item.icon}</span>
               )}
@@ -200,8 +197,22 @@ const moduleIcons = {
               <span class="home-carousel-card__eyebrow">{item.eyebrow}</span>
             </div>
 
-            <h3>{item.title}</h3>
-            <p>{item.description}</p>
+            {item.type === 'distroGroup' ? (
+              <div class="home-carousel-distro-icons">
+                {item.distros.map((distro) => (
+                  <img
+                    src={`/branding/distros/${distro.slug}.svg`}
+                    alt={`Ícone ${distro.name}`}
+                    title={distro.name}
+                  />
+                ))}
+              </div>
+            ) : (
+              <>
+                <h3>{item.title}</h3>
+                <p>{item.description}</p>
+              </>
+            )}
           </article>
         ))}
       </div>

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -957,3 +957,40 @@ a {
 }
 
 /* === /AutoM8 home info carousel v1 === */
+
+/* === AutoM8 carousel compatibility card v1 === */
+
+.home-carousel-distro-icons {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.9rem;
+  margin-top: 1.25rem;
+}
+
+.home-carousel-distro-icons img {
+  width: 4rem;
+  height: 4rem;
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  border-radius: 1.15rem;
+  background: rgba(15, 23, 42, 0.58);
+  padding: 0.55rem;
+  transition: transform 160ms ease, border-color 160ms ease;
+}
+
+.home-carousel-distro-icons img:hover {
+  transform: translateY(-2px);
+  border-color: rgba(56, 189, 248, 0.45);
+}
+
+@media (max-width: 767px) {
+  .home-carousel-distro-icons {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+
+  .home-carousel-distro-icons img {
+    width: 3.4rem;
+    height: 3.4rem;
+  }
+}
+
+/* === /AutoM8 carousel compatibility card v1 === */


### PR DESCRIPTION
Substitui as seções informativas da home por um carrossel logo abaixo da hero, consolidando funcionamento, segurança, público e compatibilidade em cards horizontais.