### PR TITLE
Centraliza documentação e releases estáveis do AutoM8

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,16 @@
 # AutoM8 - Linux Management Suite
 
-AutoM8 é uma suíte local da OSLabs para gerenciamento de sistemas Linux.
+AutoM8 é uma suíte local para preparar, diagnosticar, atualizar e manter ambientes Linux com clareza, logs e controle do usuário.
 
-O objetivo é oferecer uma CLI moderna, modular e segura para atualização, limpeza, diagnóstico, instalação de apps, perfis de uso, segurança básica, Docker, usuários e relatórios.
+**AutoM8 by OSLabs**
+
+## Site
+
+https://autom8.oslabs.com.br
 
 ## Instalação
+
+Execute com um usuário comum que tenha permissão de `sudo`:
 
 ```bash
 curl -fsSL https://autom8.oslabs.com.br/install.sh | bash
@@ -15,9 +21,20 @@ Depois da instalação:
 ```bash
 export PATH="/opt/autom8/bin:$PATH"
 autom8
+autom8 doctor
 ```
 
-## Comandos iniciais
+## Distribuição estável
+
+O instalador baixa a última versão estável publicada em GitHub Releases:
+
+```text
+https://github.com/mdmjunior/autom8/releases/latest/download/autom8-latest.tar.gz
+```
+
+A VPS não hospeda pacotes da suíte. O site publica o instalador e a documentação.
+
+## Comandos principais
 
 ```bash
 autom8
@@ -26,50 +43,58 @@ autom8 doctor
 autom8 diagnose
 autom8 update
 autom8 clean
-autom8 clean --dry-run
 autom8 security
 autom8 docker
 autom8 users
+autom8 config
 autom8 report
+autom8 apps
+autom8 profiles
+autom8 backup
+autom8 upgrade-distro
 autom8 self-update
 ```
 
-## Estrutura
+## Status dos módulos
 
-```txt
-/opt/autom8/
-├── bin/
-├── config/
-├── core/
-├── modules/
-├── profiles/
-├── catalog/
-├── i18n/
-├── logs/
-├── backups/
-├── reports/
-└── tmp/
+| Módulo | Comando | Status | Versão |
+| --- | --- | --- | --- |
+| Doctor | `autom8 doctor` | available | 0.1.0 |
+| Diagnóstico | `autom8 diagnose` | available | 0.1.0 |
+| Atualização do Sistema | `autom8 update` | available | 0.1.0 |
+| Limpeza | `autom8 clean` | available | 0.1.0 |
+| Segurança | `autom8 security` | available | 0.1.0 |
+| Docker | `autom8 docker` | available | 0.1.0 |
+| Usuários | `autom8 users` | available | 0.1.0 |
+| Configurações | `autom8 config` | available | 0.1.0 |
+| Relatórios | `autom8 report` | available | 0.1.0 |
+| Apps | `autom8 apps` | planned | 0.2.0 |
+| Perfis | `autom8 profiles` | planned | 0.2.0 |
+| Backup | `autom8 backup` | planned | 0.3.0 |
+
+## Documentação
+
+- Site: `https://autom8.oslabs.com.br/docs`
+- Fonte única: `docs/source/autom8-docs.json`
+- Help da CLI: `suite/docs/help.txt` e `suite/docs/help/`
+
+## Desenvolvimento
+
+```bash
+./scripts/sync-docs.sh
+./scripts/build-site.sh
 ```
 
-## Distros planejadas
+## Release estável
 
-- Ubuntu
-- Debian
-- Fedora
-- Rocky Linux
-- AlmaLinux
-- openSUSE
-- Arch Linux
-- Manjaro
+Após merge na `main`:
 
-## Site
+```bash
+./scripts/release-stable.sh
+```
 
-https://autom8.oslabs.com.br
+## Créditos
 
-## Status
+AutoM8 by OSLabs.
 
-Versão inicial publicada: 0.1.0.
-
-## Versão atual
-
-0.1.0 publicada em 2026-07-06.
+Criado por Marcio Moreira Junior para a comunidade Linux.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,27 @@
+# Arquitetura do AutoM8
+
+O AutoM8 é dividido em quatro áreas principais:
+
+```text
+suite/      # suíte instalada em /opt/autom8
+installer/  # instalador público install.sh
+site/       # site oficial em Astro
+scripts/    # sincronização, build, deploy, pacote e release
+docs/       # fonte única e documentos auxiliares
+```
+
+## Runtime
+
+A CLI principal fica em `suite/bin/autom8`.
+
+Os módulos ficam em `suite/modules/`.
+
+O núcleo compartilhado fica em `suite/core/`.
+
+## Documentação
+
+A documentação nasce em `docs/source/autom8-docs.json` e é sincronizada por `scripts/sync-docs.sh`.
+
+## Pacotes
+
+Pacotes são gerados temporariamente por `scripts/package.sh` e publicados por `scripts/release-stable.sh`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,24 @@
+# Documentação do AutoM8
+
+A documentação oficial é gerada a partir de uma fonte única:
+
+```text
+docs/source/autom8-docs.json
+```
+
+Esse arquivo alimenta:
+
+- README.md
+- site/src/data/docs.json
+- site/src/data/modules.json
+- site/src/data/roadmap.json
+- site/src/data/changelog.json
+- site/src/data/documentation.json
+- suite/docs/help.txt
+- suite/docs/help/<comando>.txt
+
+Para sincronizar:
+
+```bash
+./scripts/sync-docs.sh
+```

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -1,0 +1,21 @@
+# Releases do AutoM8
+
+Pacotes estáveis devem ser publicados somente no GitHub Releases.
+
+## Política
+
+- Fonte estável: GitHub Releases
+- Pacote latest: `https://github.com/mdmjunior/autom8/releases/latest/download/autom8-latest.tar.gz`
+- Padrão versionado: `https://github.com/mdmjunior/autom8/releases/download/v{version}/autom8-{version}.tar.gz`
+
+A VPS e o ambiente local de desenvolvimento não devem manter pacotes publicados da suíte.
+
+## Publicar release
+
+A partir da branch `main` limpa:
+
+```bash
+./scripts/release-stable.sh
+```
+
+O script gera pacotes temporários, cria ou atualiza a release e remove os artefatos temporários ao final.

--- a/docs/VARIABLES.md
+++ b/docs/VARIABLES.md
@@ -1,0 +1,14 @@
+# Variáveis do AutoM8
+
+| Variável | Padrão | Escopo | Descrição |
+| --- | --- | --- | --- |
+| `AUTOM8_SITE_URL` | `https://autom8.oslabs.com.br` | install, docs | URL pública do site oficial do AutoM8. |
+| `AUTOM8_GITHUB_REPO` | `mdmjunior/autom8` | install, release, self-update | Repositório GitHub usado para releases estáveis. |
+| `AUTOM8_PACKAGE_URL` | `https://github.com/mdmjunior/autom8/releases/latest/download/autom8-latest.tar.gz` | install, self-update | URL do pacote estável usado pelo instalador e validação de atualização. |
+| `AUTOM8_INSTALL_DIR` | `/opt/autom8` | install, runtime | Diretório onde a suíte é instalada. |
+| `AUTOM8_PACKAGE_OUTPUT_DIR` | `diretório temporário em /tmp` | package | Diretório temporário usado para gerar pacotes antes de publicar uma release. |
+| `AUTOM8_REPO_DIR` | `/opt/oslabs/repos/autom8` | deploy | Caminho do repositório na VPS. |
+| `AUTOM8_BRANCH` | `main` | deploy | Branch publicada na VPS. |
+| `AUTOM8_DOMAIN` | `https://autom8.oslabs.com.br` | deploy | Domínio validado no final do deploy. |
+| `AUTOM8_SERVICE_NAME` | `` | deploy | Nome do serviço Docker Swarm que deve ser reiniciado após o build. |
+| `AUTOM8_RESTART_SERVICE` | `1` | deploy | Use 0 para validar build sem reiniciar o serviço. |

--- a/docs/source/autom8-docs.json
+++ b/docs/source/autom8-docs.json
@@ -1,0 +1,496 @@
+{
+  "product": {
+    "name": "AutoM8",
+    "fullName": "AutoM8 - Linux Management Suite",
+    "brand": "AutoM8 by OSLabs",
+    "siteUrl": "https://autom8.oslabs.com.br",
+    "githubRepo": "mdmjunior/autom8",
+    "currentVersion": "0.1.0",
+    "currentDate": "2026-07-06",
+    "summary": "AutoM8 é uma suíte local para preparar, diagnosticar, atualizar e manter ambientes Linux com clareza, logs e controle do usuário.",
+    "positioning": "Automação Linux local, segura e auditável para usuários iniciantes, técnicos e administradores."
+  },
+  "releasePolicy": {
+    "stableSource": "GitHub Releases",
+    "latestPackageUrl": "https://github.com/mdmjunior/autom8/releases/latest/download/autom8-latest.tar.gz",
+    "versionedPackagePattern": "https://github.com/mdmjunior/autom8/releases/download/v{version}/autom8-{version}.tar.gz",
+    "sitePackagePolicy": "A VPS e o build do site não devem hospedar pacotes da suíte. O site publica apenas o instalador e a documentação.",
+    "installerPolicy": "O install.sh deve baixar sempre o pacote estável mais recente publicado no GitHub Releases."
+  },
+  "variables": [
+    {
+      "name": "AUTOM8_SITE_URL",
+      "default": "https://autom8.oslabs.com.br",
+      "scope": "install, docs",
+      "description": "URL pública do site oficial do AutoM8."
+    },
+    {
+      "name": "AUTOM8_GITHUB_REPO",
+      "default": "mdmjunior/autom8",
+      "scope": "install, release, self-update",
+      "description": "Repositório GitHub usado para releases estáveis."
+    },
+    {
+      "name": "AUTOM8_PACKAGE_URL",
+      "default": "https://github.com/mdmjunior/autom8/releases/latest/download/autom8-latest.tar.gz",
+      "scope": "install, self-update",
+      "description": "URL do pacote estável usado pelo instalador e validação de atualização."
+    },
+    {
+      "name": "AUTOM8_INSTALL_DIR",
+      "default": "/opt/autom8",
+      "scope": "install, runtime",
+      "description": "Diretório onde a suíte é instalada."
+    },
+    {
+      "name": "AUTOM8_PACKAGE_OUTPUT_DIR",
+      "default": "diretório temporário em /tmp",
+      "scope": "package",
+      "description": "Diretório temporário usado para gerar pacotes antes de publicar uma release."
+    },
+    {
+      "name": "AUTOM8_REPO_DIR",
+      "default": "/opt/oslabs/repos/autom8",
+      "scope": "deploy",
+      "description": "Caminho do repositório na VPS."
+    },
+    {
+      "name": "AUTOM8_BRANCH",
+      "default": "main",
+      "scope": "deploy",
+      "description": "Branch publicada na VPS."
+    },
+    {
+      "name": "AUTOM8_DOMAIN",
+      "default": "https://autom8.oslabs.com.br",
+      "scope": "deploy",
+      "description": "Domínio validado no final do deploy."
+    },
+    {
+      "name": "AUTOM8_SERVICE_NAME",
+      "default": "",
+      "scope": "deploy",
+      "description": "Nome do serviço Docker Swarm que deve ser reiniciado após o build."
+    },
+    {
+      "name": "AUTOM8_RESTART_SERVICE",
+      "default": "1",
+      "scope": "deploy",
+      "description": "Use 0 para validar build sem reiniciar o serviço."
+    }
+  ],
+  "requirements": [
+    "Usuário comum com permissão de sudo.",
+    "bash, curl, tar, gzip, awk, sed, grep, find e sudo.",
+    "Gerenciador de pacotes suportado: apt, dnf, zypper ou pacman.",
+    "gum é instalado pelo instalador para melhorar a interface interativa.",
+    "Docker, Flatpak, Snap, jq, rsync, nmap e lsof podem ser usados por módulos específicos quando disponíveis."
+  ],
+  "install": {
+    "command": "curl -fsSL https://autom8.oslabs.com.br/install.sh | bash",
+    "after": [
+      "export PATH=\"/opt/autom8/bin:$PATH\"",
+      "autom8",
+      "autom8 doctor"
+    ],
+    "notes": [
+      "Não execute o instalador diretamente como root.",
+      "O instalador baixa o pacote estável mais recente do GitHub Releases.",
+      "A instalação padrão usa /opt/autom8.",
+      "Ao final, o instalador executa autom8 --version e autom8 doctor."
+    ]
+  },
+  "commands": [
+    {
+      "slug": "menu",
+      "command": "autom8",
+      "status": "available",
+      "since": "0.1.0",
+      "summary": "Abre o menu interativo principal.",
+      "details": [
+        "Mostra o dashboard local com distro, permissões, disco, memória, Docker e firewall.",
+        "Permite acessar módulos sem decorar comandos."
+      ],
+      "examples": ["autom8"]
+    },
+    {
+      "slug": "version",
+      "command": "autom8 --version",
+      "status": "available",
+      "since": "0.1.0",
+      "summary": "Mostra a versão instalada.",
+      "details": ["Lê a versão instalada a partir do arquivo VERSION dentro da suíte."],
+      "examples": ["autom8 --version"]
+    },
+    {
+      "slug": "doctor",
+      "command": "autom8 doctor",
+      "status": "available",
+      "since": "0.1.0",
+      "summary": "Valida instalação, estrutura, permissões, dependências, PATH, logs e relatórios.",
+      "details": [
+        "Gera relatório em reports/doctor-<data>.txt.",
+        "Verifica diretórios principais, arquivos obrigatórios, comandos obrigatórios e comandos opcionais.",
+        "Indicado após instalar, atualizar ou mover a suíte."
+      ],
+      "examples": ["autom8 doctor"]
+    },
+    {
+      "slug": "diagnose",
+      "command": "autom8 diagnose",
+      "status": "available",
+      "since": "0.1.0",
+      "summary": "Gera diagnóstico local do sistema.",
+      "details": [
+        "Coleta informações de sistema, kernel, CPU, memória, disco, rede, DNS, serviços, firewall, portas, Docker, usuários e sessão gráfica.",
+        "Gera relatório em reports/diagnostic-<data>.txt."
+      ],
+      "examples": ["autom8 diagnose"]
+    },
+    {
+      "slug": "update",
+      "command": "autom8 update",
+      "status": "available",
+      "since": "0.1.0",
+      "summary": "Atualiza repositórios e pacotes do sistema com confirmação.",
+      "details": [
+        "Suporta apt, dnf, zypper e pacman.",
+        "Bloqueia execução em distros não suportadas oficialmente.",
+        "Exige sudo e registra a execução em logs."
+      ],
+      "examples": ["autom8 update", "autom8 update --dry-run"]
+    },
+    {
+      "slug": "clean",
+      "command": "autom8 clean",
+      "status": "available",
+      "since": "0.1.0",
+      "summary": "Executa limpeza segura de caches, temporários e arquivos antigos.",
+      "details": [
+        "Limpa cache do gerenciador de pacotes conforme a distro.",
+        "Remove temporários antigos em /tmp e /var/tmp.",
+        "Remove logs rotacionados antigos.",
+        "Pode limpar caches seguros de usuários, preservando caches de navegadores conhecidos.",
+        "Suporta simulação com --dry-run."
+      ],
+      "examples": ["autom8 clean", "autom8 clean --dry-run"]
+    },
+    {
+      "slug": "security",
+      "command": "autom8 security",
+      "status": "available",
+      "since": "0.1.0",
+      "summary": "Executa checagem básica de segurança local.",
+      "details": [
+        "Mostra status de firewall conhecido.",
+        "Lista portas em escuta.",
+        "Verifica status básico de SSH."
+      ],
+      "examples": ["autom8 security"]
+    },
+    {
+      "slug": "docker",
+      "command": "autom8 docker",
+      "status": "available",
+      "since": "0.1.0",
+      "summary": "Mostra informações do Docker quando disponível.",
+      "details": [
+        "Mostra versão do Docker.",
+        "Lista containers em execução.",
+        "Mostra uso de disco do Docker."
+      ],
+      "examples": ["autom8 docker"]
+    },
+    {
+      "slug": "users",
+      "command": "autom8 users",
+      "status": "available",
+      "since": "0.1.0",
+      "summary": "Lista usuários locais e grupos administrativos.",
+      "details": [
+        "Mostra usuários com login permitido.",
+        "Mostra grupos sudo, wheel e admin quando existem.",
+        "Ações de bloqueio, shell e sudo ficam para versão futura."
+      ],
+      "examples": ["autom8 users"]
+    },
+    {
+      "slug": "config",
+      "command": "autom8 config",
+      "status": "available",
+      "since": "0.1.0",
+      "summary": "Permite alterar configurações básicas da suíte.",
+      "details": [
+        "Permite selecionar idioma.",
+        "Permite selecionar modo padrão.",
+        "Permite selecionar nível de limpeza padrão.",
+        "Permite visualizar a configuração atual."
+      ],
+      "examples": ["autom8 config"]
+    },
+    {
+      "slug": "report",
+      "command": "autom8 report",
+      "status": "available",
+      "since": "0.1.0",
+      "summary": "Lista e exporta relatórios gerados.",
+      "details": [
+        "Lista arquivos em reports/.",
+        "Pode exportar relatórios em tar.gz pelo menu.",
+        "Também aceita autom8 report export para exportar logs e relatórios."
+      ],
+      "examples": ["autom8 report", "autom8 report export"]
+    },
+    {
+      "slug": "apps",
+      "command": "autom8 apps",
+      "status": "planned",
+      "since": "0.2.0",
+      "summary": "Instalação e remoção de aplicativos por catálogo.",
+      "details": ["Na versão 0.1.0, o módulo existe como placeholder e será implementado na 0.2.0."],
+      "examples": ["autom8 apps"]
+    },
+    {
+      "slug": "profiles",
+      "command": "autom8 profiles",
+      "status": "planned",
+      "since": "0.2.0",
+      "summary": "Aplicação de perfis YAML para preparar ambientes.",
+      "details": ["Na versão 0.1.0, o módulo existe como placeholder e será implementado na 0.2.0."],
+      "examples": ["autom8 profiles"]
+    },
+    {
+      "slug": "backup",
+      "command": "autom8 backup",
+      "status": "planned",
+      "since": "0.3.0",
+      "summary": "Backups simples antes de operações sensíveis.",
+      "details": ["Na versão 0.1.0, o módulo existe como placeholder e será implementado na 0.3.0."],
+      "examples": ["autom8 backup"]
+    },
+    {
+      "slug": "upgrade-distro",
+      "command": "autom8 upgrade-distro",
+      "status": "planned",
+      "since": "future",
+      "summary": "Preparação futura para upgrade de versão da distro.",
+      "details": ["Na versão 0.1.0, o módulo apenas informa que será implementado em versão futura."],
+      "examples": ["autom8 upgrade-distro"]
+    },
+    {
+      "slug": "self-update",
+      "command": "autom8 self-update",
+      "status": "partial",
+      "since": "0.1.0",
+      "summary": "Valida o pacote estável mais recente publicado no GitHub Releases.",
+      "details": [
+        "Na versão atual, baixa e valida o tar.gz estável quando o usuário confirma.",
+        "Atualização automática com rollback será implementada em versão futura."
+      ],
+      "examples": ["autom8 self-update"]
+    }
+  ],
+  "modules": [
+    {
+      "name": "Doctor",
+      "slug": "doctor",
+      "status": "available",
+      "version": "0.1.0",
+      "command": "autom8 doctor",
+      "description": "Valida instalação, estrutura, permissões, dependências, PATH, logs e relatórios."
+    },
+    {
+      "name": "Diagnóstico",
+      "slug": "diagnose",
+      "status": "available",
+      "version": "0.1.0",
+      "command": "autom8 diagnose",
+      "description": "Gera relatório local com informações de sistema, hardware, rede, firewall, Docker e usuários."
+    },
+    {
+      "name": "Atualização do Sistema",
+      "slug": "update",
+      "status": "available",
+      "version": "0.1.0",
+      "command": "autom8 update",
+      "description": "Atualiza pacotes usando apt, dnf, zypper ou pacman, com confirmação e logs."
+    },
+    {
+      "name": "Limpeza",
+      "slug": "clean",
+      "status": "available",
+      "version": "0.1.0",
+      "command": "autom8 clean",
+      "description": "Executa limpeza segura e suporta simulação com --dry-run."
+    },
+    {
+      "name": "Segurança",
+      "slug": "security",
+      "status": "available",
+      "version": "0.1.0",
+      "command": "autom8 security",
+      "description": "Mostra firewall, portas em escuta e status básico de SSH."
+    },
+    {
+      "name": "Docker",
+      "slug": "docker",
+      "status": "available",
+      "version": "0.1.0",
+      "command": "autom8 docker",
+      "description": "Mostra versão, containers em execução e uso de disco do Docker quando disponível."
+    },
+    {
+      "name": "Usuários",
+      "slug": "users",
+      "status": "available",
+      "version": "0.1.0",
+      "command": "autom8 users",
+      "description": "Lista usuários com login permitido e grupos administrativos."
+    },
+    {
+      "name": "Configurações",
+      "slug": "config",
+      "status": "available",
+      "version": "0.1.0",
+      "command": "autom8 config",
+      "description": "Permite ajustar idioma, modo padrão, nível de limpeza e visualizar configuração."
+    },
+    {
+      "name": "Relatórios",
+      "slug": "report",
+      "status": "available",
+      "version": "0.1.0",
+      "command": "autom8 report",
+      "description": "Lista e exporta relatórios gerados pela suíte."
+    },
+    {
+      "name": "Apps",
+      "slug": "apps",
+      "status": "planned",
+      "version": "0.2.0",
+      "command": "autom8 apps",
+      "description": "Instalação e remoção de aplicativos por catálogo. Planejado para 0.2.0."
+    },
+    {
+      "name": "Perfis",
+      "slug": "profiles",
+      "status": "planned",
+      "version": "0.2.0",
+      "command": "autom8 profiles",
+      "description": "Perfis YAML para preparar ambientes. Planejado para 0.2.0."
+    },
+    {
+      "name": "Backup",
+      "slug": "backup",
+      "status": "planned",
+      "version": "0.3.0",
+      "command": "autom8 backup",
+      "description": "Backups simples antes de operações sensíveis. Planejado para 0.3.0."
+    }
+  ],
+  "roadmap": [
+    {
+      "version": "0.1.0",
+      "title": "Base funcional e release estável",
+      "items": [
+        "Estrutura /opt/autom8.",
+        "Instalador install.sh.",
+        "Comando autom8.",
+        "Detecção de distro e gerenciador de pacotes.",
+        "Logs próprios.",
+        "Menu interativo com gum.",
+        "Doctor.",
+        "Diagnóstico.",
+        "Update básico.",
+        "Limpeza segura com dry-run.",
+        "Checagens básicas de segurança.",
+        "Docker status.",
+        "Usuários.",
+        "Configurações.",
+        "Relatórios.",
+        "Site oficial.",
+        "Distribuição estável via GitHub Releases."
+      ]
+    },
+    {
+      "version": "0.2.0",
+      "title": "Apps e perfis",
+      "items": [
+        "Catálogo YAML.",
+        "Instalação e remoção de apps.",
+        "Perfis YAML.",
+        "Modo mínimo seguro.",
+        "Modo completo.",
+        "Seleção individual de apps.",
+        "Flatpak e Flathub."
+      ]
+    },
+    {
+      "version": "0.3.0",
+      "title": "Operação, backups e segurança expandida",
+      "items": [
+        "Backup funcional.",
+        "Rollback parcial.",
+        "Security expandido.",
+        "Users com ações administrativas.",
+        "Docker com manutenção orientada.",
+        "Relatórios exportáveis mais completos."
+      ]
+    },
+    {
+      "version": "1.0.0",
+      "title": "Primeira versão estável completa",
+      "items": [
+        "Suporte testado nas distros oficiais.",
+        "Documentação completa.",
+        "Changelog versionado.",
+        "Instalação estável.",
+        "Self-update com rollback documentado.",
+        "Pipeline de release estável documentado."
+      ]
+    }
+  ],
+  "changelog": [
+    {
+      "version": "0.1.0",
+      "date": "2026-07-06",
+      "status": "published",
+      "changes": [
+        "Estrutura inicial da suíte AutoM8.",
+        "Primeiro instalador público.",
+        "Primeiro site oficial.",
+        "Comando autom8 com menu interativo.",
+        "Módulos doctor, diagnose, update e clean.",
+        "Checagens básicas de security, docker e users.",
+        "Configurações e relatórios iniciais.",
+        "Melhorado comportamento do autom8 clean --dry-run.",
+        "Distribuição estável movida para GitHub Releases.",
+        "install.sh passa a baixar o pacote estável mais recente do GitHub Releases.",
+        "Build do site deixa de publicar pacotes da suíte na VPS.",
+        "Documentação passa a usar fonte única para site, README, roadmap, changelog e help."
+      ]
+    }
+  ],
+  "troubleshooting": [
+    {
+      "title": "Comando autom8 não encontrado",
+      "solution": "Execute export PATH=\"/opt/autom8/bin:$PATH\" ou abra uma nova sessão de terminal após a instalação."
+    },
+    {
+      "title": "Instalador bloqueou execução como root",
+      "solution": "Execute o instalador com um usuário comum que tenha permissão de sudo."
+    },
+    {
+      "title": "Doctor encontrou comandos opcionais ausentes",
+      "solution": "Comandos opcionais podem ser instalados conforme necessidade. Falhas críticas aparecem separadas de avisos."
+    },
+    {
+      "title": "Distro não suportada oficialmente",
+      "solution": "Na versão atual, ações administrativas ficam bloqueadas e diagnóstico permanece disponível."
+    },
+    {
+      "title": "GitHub Release sem pacote latest",
+      "solution": "Publique a release estável com scripts/release-stable.sh a partir da branch main após merge."
+    }
+  ]
+}

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -2,7 +2,8 @@
 set -euo pipefail
 
 AUTOM8_SITE_URL="${AUTOM8_SITE_URL:-https://autom8.oslabs.com.br}"
-AUTOM8_PACKAGE_URL="${AUTOM8_PACKAGE_URL:-$AUTOM8_SITE_URL/downloads/autom8-latest.tar.gz}"
+AUTOM8_GITHUB_REPO="${AUTOM8_GITHUB_REPO:-mdmjunior/autom8}"
+AUTOM8_PACKAGE_URL="${AUTOM8_PACKAGE_URL:-https://github.com/${AUTOM8_GITHUB_REPO}/releases/latest/download/autom8-latest.tar.gz}"
 AUTOM8_INSTALL_DIR="${AUTOM8_INSTALL_DIR:-/opt/autom8}"
 
 info() {
@@ -315,7 +316,8 @@ install_package() {
   local tmp_dir
   tmp_dir="$(mktemp -d)"
 
-  info "Baixando pacote: $AUTOM8_PACKAGE_URL"
+  info "Baixando última versão estável do AutoM8."
+  info "Origem: $AUTOM8_PACKAGE_URL"
   curl -fsSL "$AUTOM8_PACKAGE_URL" -o "$tmp_dir/autom8.tar.gz"
 
   info "Instalando em: $AUTOM8_INSTALL_DIR"

--- a/scripts/build-site.sh
+++ b/scripts/build-site.sh
@@ -5,6 +5,8 @@ PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 cd "$PROJECT_ROOT"
 
+./scripts/sync-docs.sh
+
 cp installer/install.sh site/public/install.sh
 chmod +x site/public/install.sh
 

--- a/scripts/build-site.sh
+++ b/scripts/build-site.sh
@@ -5,7 +5,6 @@ PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 cd "$PROJECT_ROOT"
 
-./scripts/package.sh
 cp installer/install.sh site/public/install.sh
 chmod +x site/public/install.sh
 
@@ -15,3 +14,5 @@ npm install
 npm run build
 
 echo "Site build concluído."
+echo "Observação: pacotes da suíte não são gerados no build do site."
+echo "Pacotes estáveis são publicados somente via GitHub Releases."

--- a/scripts/deploy-site-vps.sh
+++ b/scripts/deploy-site-vps.sh
@@ -46,13 +46,13 @@ git checkout "$BRANCH"
 git pull --ff-only origin "$BRANCH"
 
 log "Garantindo permissão dos scripts..."
-chmod +x scripts/package.sh
 chmod +x scripts/build-site.sh
+chmod +x scripts/deploy-site-vps.sh
 
-log "Gerando pacote da suíte e build do site..."
+log "Gerando build do site..."
 ./scripts/build-site.sh
 
-log "Validando artefatos do build..."
+log "Validando artefatos do site..."
 
 if [[ ! -d "$REPO_DIR/site/dist" ]]; then
   error "Build não gerou site/dist"
@@ -64,14 +64,14 @@ if [[ ! -f "$REPO_DIR/site/dist/install.sh" ]]; then
   exit 1
 fi
 
-if [[ ! -f "$REPO_DIR/site/dist/downloads/autom8-latest.tar.gz" ]]; then
-  error "Build não gerou site/dist/downloads/autom8-latest.tar.gz"
-  exit 1
+if [[ -d "$REPO_DIR/site/dist/downloads" ]]; then
+  warn "Diretório site/dist/downloads encontrado."
+  warn "Pacotes da suíte não devem mais ser publicados pela VPS."
+  warn "Revise se há arquivos legados no site/public/downloads."
 fi
 
-log "Artefatos validados:"
+log "Artefatos do site validados:"
 ls -lah "$REPO_DIR/site/dist" | head
-ls -lah "$REPO_DIR/site/dist/downloads"
 
 if [[ "$RESTART_SERVICE" == "1" ]]; then
   if [[ -n "$SERVICE_NAME" ]]; then
@@ -90,5 +90,6 @@ fi
 
 log "Testando domínio..."
 curl -I "$DOMAIN" || true
+curl -I "$DOMAIN/install.sh" || true
 
 log "Deploy finalizado."

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -6,6 +6,10 @@ SUITE_DIR="$PROJECT_ROOT/suite"
 
 VERSION="$(tr -d '[:space:]' < "$SUITE_DIR/VERSION")"
 
+if [[ -x "$PROJECT_ROOT/scripts/sync-docs.sh" && "${AUTOM8_SKIP_DOC_SYNC:-0}" != "1" ]]; then
+  "$PROJECT_ROOT/scripts/sync-docs.sh"
+fi
+
 if [[ -z "$VERSION" ]]; then
   echo "ERRO: suite/VERSION está vazio." >&2
   exit 1

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -3,14 +3,20 @@ set -euo pipefail
 
 PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SUITE_DIR="$PROJECT_ROOT/suite"
-DIST_DIR="$PROJECT_ROOT/dist"
 
 VERSION="$(tr -d '[:space:]' < "$SUITE_DIR/VERSION")"
 
-mkdir -p "$DIST_DIR"
+if [[ -z "$VERSION" ]]; then
+  echo "ERRO: suite/VERSION está vazio." >&2
+  exit 1
+fi
 
-PACKAGE_VERSIONED="$DIST_DIR/autom8-${VERSION}.tar.gz"
-PACKAGE_LATEST="$DIST_DIR/autom8-latest.tar.gz"
+OUTPUT_DIR="${AUTOM8_PACKAGE_OUTPUT_DIR:-$(mktemp -d /tmp/autom8-package-${VERSION}-XXXXXX)}"
+
+mkdir -p "$OUTPUT_DIR"
+
+PACKAGE_VERSIONED="$OUTPUT_DIR/autom8-${VERSION}.tar.gz"
+PACKAGE_LATEST="$OUTPUT_DIR/autom8-latest.tar.gz"
 
 tar \
   --exclude='logs/*' \
@@ -22,13 +28,13 @@ tar \
 
 cp "$PACKAGE_VERSIONED" "$PACKAGE_LATEST"
 
-mkdir -p "$PROJECT_ROOT/site/public/downloads"
-cp "$PACKAGE_VERSIONED" "$PROJECT_ROOT/site/public/downloads/"
-cp "$PACKAGE_LATEST" "$PROJECT_ROOT/site/public/downloads/"
-
-echo "Pacotes gerados:"
+echo "Pacotes gerados temporariamente:"
 echo "$PACKAGE_VERSIONED"
 echo "$PACKAGE_LATEST"
 echo
-echo "Copiados para:"
-echo "$PROJECT_ROOT/site/public/downloads/"
+echo "Diretório temporário:"
+echo "$OUTPUT_DIR"
+echo
+echo "Observação:"
+echo "Os pacotes não são copiados para o site, VPS ou repositório local."
+echo "Use scripts/release-stable.sh para publicar no GitHub Releases."

--- a/scripts/release-stable.sh
+++ b/scripts/release-stable.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REPO="${AUTOM8_GITHUB_REPO:-mdmjunior/autom8}"
+VERSION="$(tr -d '[:space:]' < "$PROJECT_ROOT/suite/VERSION")"
+TAG="v${VERSION}"
+
+log() {
+  printf '\033[1;34m[AutoM8 Release]\033[0m %s\n' "$1"
+}
+
+warn() {
+  printf '\033[1;33m[AutoM8 Release]\033[0m %s\n' "$1"
+}
+
+error() {
+  printf '\033[1;31m[AutoM8 Release]\033[0m %s\n' "$1" >&2
+}
+
+cd "$PROJECT_ROOT"
+
+if [[ -z "$VERSION" ]]; then
+  error "suite/VERSION está vazio."
+  exit 1
+fi
+
+if [[ -n "$(git status --porcelain)" ]]; then
+  error "Existem alterações locais não commitadas."
+  git status --short
+  exit 1
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+  error "GitHub CLI não encontrado. Instale e autentique com: gh auth login"
+  exit 1
+fi
+
+if ! gh auth status >/dev/null 2>&1; then
+  error "GitHub CLI não está autenticado. Rode: gh auth login"
+  exit 1
+fi
+
+CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+if [[ "$CURRENT_BRANCH" != "main" ]]; then
+  error "Releases estáveis devem ser publicados a partir da branch main."
+  error "Branch atual: $CURRENT_BRANCH"
+  exit 1
+fi
+
+log "Atualizando main..."
+git fetch origin main
+git pull --ff-only origin main
+
+log "Validando build do site antes da release..."
+./scripts/build-site.sh
+
+PACKAGE_DIR="$(mktemp -d /tmp/autom8-release-${VERSION}-XXXXXX)"
+cleanup() {
+  rm -rf "$PACKAGE_DIR"
+}
+trap cleanup EXIT
+
+log "Gerando pacotes temporários em $PACKAGE_DIR..."
+AUTOM8_PACKAGE_OUTPUT_DIR="$PACKAGE_DIR" ./scripts/package.sh
+
+PACKAGE_VERSIONED="$PACKAGE_DIR/autom8-${VERSION}.tar.gz"
+PACKAGE_LATEST="$PACKAGE_DIR/autom8-latest.tar.gz"
+
+test -f "$PACKAGE_VERSIONED"
+test -f "$PACKAGE_LATEST"
+
+log "Pacotes gerados:"
+ls -lah "$PACKAGE_DIR"
+
+if gh release view "$TAG" --repo "$REPO" >/dev/null 2>&1; then
+  warn "Release $TAG já existe."
+  warn "Os assets serão substituídos."
+  gh release upload "$TAG" "$PACKAGE_VERSIONED" "$PACKAGE_LATEST" --repo "$REPO" --clobber
+else
+  log "Criando release $TAG..."
+  gh release create "$TAG" \
+    "$PACKAGE_VERSIONED" \
+    "$PACKAGE_LATEST" \
+    --repo "$REPO" \
+    --target main \
+    --title "AutoM8 ${VERSION}" \
+    --notes "Release estável do AutoM8 ${VERSION}."
+fi
+
+log "Validando assets publicados..."
+gh release view "$TAG" --repo "$REPO" --json tagName,name,isLatest,url
+
+log "Release estável publicada."
+log "URL estável usada pelo install.sh:"
+echo "https://github.com/${REPO}/releases/latest/download/autom8-latest.tar.gz"

--- a/scripts/sync-docs.sh
+++ b/scripts/sync-docs.sh
@@ -1,0 +1,324 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SOURCE_FILE="$PROJECT_ROOT/docs/source/autom8-docs.json"
+
+if [[ ! -f "$SOURCE_FILE" ]]; then
+  echo "ERRO: fonte de documentação não encontrada: $SOURCE_FILE" >&2
+  exit 1
+fi
+
+python3 - <<'PY'
+import json
+from pathlib import Path
+
+root = Path.cwd()
+source = json.loads((root / "docs/source/autom8-docs.json").read_text())
+
+product = source["product"]
+commands = source["commands"]
+modules = source["modules"]
+variables = source["variables"]
+roadmap = source["roadmap"]
+changelog = source["changelog"]
+requirements = source["requirements"]
+install = source["install"]
+release_policy = source["releasePolicy"]
+troubleshooting = source["troubleshooting"]
+
+def write_text(path, content):
+    path = root / path
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content.rstrip() + "\n")
+
+def write_json(path, data):
+    path = root / path
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, ensure_ascii=False, indent=2) + "\n")
+
+def md(lines):
+    return "\n".join(lines)
+
+available = [c for c in commands if c["status"] == "available"]
+partial = [c for c in commands if c["status"] == "partial"]
+planned = [c for c in commands if c["status"] == "planned"]
+
+write_json("site/src/data/docs.json", [
+    {
+        "command": c["command"],
+        "description": c["summary"],
+        "status": c["status"],
+        "since": c["since"],
+        "slug": c["slug"]
+    }
+    for c in commands
+])
+
+write_json("site/src/data/modules.json", modules)
+write_json("site/src/data/roadmap.json", roadmap)
+write_json("site/src/data/changelog.json", changelog)
+
+write_json("site/src/data/documentation.json", {
+    "product": product,
+    "releasePolicy": release_policy,
+    "install": install,
+    "requirements": requirements,
+    "variables": variables,
+    "commands": commands,
+    "modules": modules,
+    "troubleshooting": troubleshooting
+})
+
+help_lines = [
+    f"{product['fullName']}",
+    "",
+    product["summary"],
+    "",
+    "Uso:",
+    "  autom8",
+    "  autom8 help",
+    "  autom8 help <comando>",
+    "  autom8 --version",
+    "",
+    "Comandos disponíveis:"
+]
+
+for c in available:
+    help_lines.append(f"  {c['command']:<24} {c['summary']}")
+
+if partial:
+    help_lines.extend(["", "Comandos parciais:"])
+    for c in partial:
+        help_lines.append(f"  {c['command']:<24} {c['summary']}")
+
+if planned:
+    help_lines.extend(["", "Comandos planejados:"])
+    for c in planned:
+        help_lines.append(f"  {c['command']:<24} {c['summary']}")
+
+help_lines.extend([
+    "",
+    "Ajuda por comando:",
+    "  autom8 help doctor",
+    "  autom8 help clean",
+    "  autom8 help update",
+    "",
+    f"Site: {product['siteUrl']}",
+    f"Release estável: {release_policy['latestPackageUrl']}"
+])
+
+write_text("suite/docs/help.txt", "\n".join(help_lines))
+
+for c in commands:
+    lines = [
+        f"{product['name']} help: {c['command']}",
+        "",
+        f"Status: {c['status']}",
+        f"Desde: {c['since']}",
+        "",
+        c["summary"],
+        ""
+    ]
+
+    if c["details"]:
+        lines.append("Detalhes:")
+        for item in c["details"]:
+            lines.append(f"- {item}")
+        lines.append("")
+
+    if c["examples"]:
+        lines.append("Exemplos:")
+        for item in c["examples"]:
+            lines.append(f"  {item}")
+
+    write_text(f"suite/docs/help/{c['slug']}.txt", "\n".join(lines))
+
+readme = [
+    f"# {product['fullName']}",
+    "",
+    product["summary"],
+    "",
+    f"**{product['brand']}**",
+    "",
+    "## Site",
+    "",
+    product["siteUrl"],
+    "",
+    "## Instalação",
+    "",
+    "Execute com um usuário comum que tenha permissão de `sudo`:",
+    "",
+    "```bash",
+    install["command"],
+    "```",
+    "",
+    "Depois da instalação:",
+    "",
+    "```bash",
+    *install["after"],
+    "```",
+    "",
+    "## Distribuição estável",
+    "",
+    f"O instalador baixa a última versão estável publicada em GitHub Releases:",
+    "",
+    "```text",
+    release_policy["latestPackageUrl"],
+    "```",
+    "",
+    "A VPS não hospeda pacotes da suíte. O site publica o instalador e a documentação.",
+    "",
+    "## Comandos principais",
+    "",
+    "```bash",
+]
+
+for c in commands:
+    readme.append(c["command"])
+
+readme.extend([
+    "```",
+    "",
+    "## Status dos módulos",
+    "",
+    "| Módulo | Comando | Status | Versão |",
+    "| --- | --- | --- | --- |"
+])
+
+for m in modules:
+    readme.append(f"| {m['name']} | `{m['command']}` | {m['status']} | {m['version']} |")
+
+readme.extend([
+    "",
+    "## Documentação",
+    "",
+    "- Site: `https://autom8.oslabs.com.br/docs`",
+    "- Fonte única: `docs/source/autom8-docs.json`",
+    "- Help da CLI: `suite/docs/help.txt` e `suite/docs/help/`",
+    "",
+    "## Desenvolvimento",
+    "",
+    "```bash",
+    "./scripts/sync-docs.sh",
+    "./scripts/build-site.sh",
+    "```",
+    "",
+    "## Release estável",
+    "",
+    "Após merge na `main`:",
+    "",
+    "```bash",
+    "./scripts/release-stable.sh",
+    "```",
+    "",
+    "## Créditos",
+    "",
+    f"{product['brand']}.",
+    "",
+    "Criado por Marcio Moreira Junior para a comunidade Linux."
+])
+
+write_text("README.md", md(readme))
+
+docs_readme = [
+    "# Documentação do AutoM8",
+    "",
+    "A documentação oficial é gerada a partir de uma fonte única:",
+    "",
+    "```text",
+    "docs/source/autom8-docs.json",
+    "```",
+    "",
+    "Esse arquivo alimenta:",
+    "",
+    "- README.md",
+    "- site/src/data/docs.json",
+    "- site/src/data/modules.json",
+    "- site/src/data/roadmap.json",
+    "- site/src/data/changelog.json",
+    "- site/src/data/documentation.json",
+    "- suite/docs/help.txt",
+    "- suite/docs/help/<comando>.txt",
+    "",
+    "Para sincronizar:",
+    "",
+    "```bash",
+    "./scripts/sync-docs.sh",
+    "```"
+]
+
+write_text("docs/README.md", md(docs_readme))
+
+releases_md = [
+    "# Releases do AutoM8",
+    "",
+    "Pacotes estáveis devem ser publicados somente no GitHub Releases.",
+    "",
+    "## Política",
+    "",
+    f"- Fonte estável: {release_policy['stableSource']}",
+    f"- Pacote latest: `{release_policy['latestPackageUrl']}`",
+    f"- Padrão versionado: `{release_policy['versionedPackagePattern']}`",
+    "",
+    "A VPS e o ambiente local de desenvolvimento não devem manter pacotes publicados da suíte.",
+    "",
+    "## Publicar release",
+    "",
+    "A partir da branch `main` limpa:",
+    "",
+    "```bash",
+    "./scripts/release-stable.sh",
+    "```",
+    "",
+    "O script gera pacotes temporários, cria ou atualiza a release e remove os artefatos temporários ao final."
+]
+
+write_text("docs/RELEASES.md", md(releases_md))
+
+variables_md = [
+    "# Variáveis do AutoM8",
+    "",
+    "| Variável | Padrão | Escopo | Descrição |",
+    "| --- | --- | --- | --- |"
+]
+
+for v in variables:
+    variables_md.append(f"| `{v['name']}` | `{v['default']}` | {v['scope']} | {v['description']} |")
+
+write_text("docs/VARIABLES.md", md(variables_md))
+
+architecture_md = [
+    "# Arquitetura do AutoM8",
+    "",
+    "O AutoM8 é dividido em quatro áreas principais:",
+    "",
+    "```text",
+    "suite/      # suíte instalada em /opt/autom8",
+    "installer/  # instalador público install.sh",
+    "site/       # site oficial em Astro",
+    "scripts/    # sincronização, build, deploy, pacote e release",
+    "docs/       # fonte única e documentos auxiliares",
+    "```",
+    "",
+    "## Runtime",
+    "",
+    "A CLI principal fica em `suite/bin/autom8`.",
+    "",
+    "Os módulos ficam em `suite/modules/`.",
+    "",
+    "O núcleo compartilhado fica em `suite/core/`.",
+    "",
+    "## Documentação",
+    "",
+    "A documentação nasce em `docs/source/autom8-docs.json` e é sincronizada por `scripts/sync-docs.sh`.",
+    "",
+    "## Pacotes",
+    "",
+    "Pacotes são gerados temporariamente por `scripts/package.sh` e publicados por `scripts/release-stable.sh`."
+]
+
+write_text("docs/ARCHITECTURE.md", md(architecture_md))
+
+print("Documentação sincronizada com sucesso.")
+PY

--- a/site/src/data/changelog.json
+++ b/site/src/data/changelog.json
@@ -13,7 +13,7 @@
       "Primeira versão funcional publicada.",
       "Site oficial publicado em https://autom8.oslabs.com.br.",
       "Instalador público disponível em /install.sh.",
-      "Pacotes públicos disponíveis em /downloads/autom8-latest.tar.gz e /downloads/autom8-0.1.0.tar.gz."
+      "Pacotes estáveis passam a ser distribuídos por GitHub Releases."
     ],
     "status": "published"
   }

--- a/site/src/data/changelog.json
+++ b/site/src/data/changelog.json
@@ -2,19 +2,20 @@
   {
     "version": "0.1.0",
     "date": "2026-07-06",
+    "status": "published",
     "changes": [
       "Estrutura inicial da suíte AutoM8.",
-      "Primeiro instalador local e remoto.",
+      "Primeiro instalador público.",
       "Primeiro site oficial.",
-      "Módulos iniciais de diagnóstico, update e limpeza segura.",
-      "Adicionado comando autom8 doctor.",
-      "Melhorado comportamento do autom8 clean --dry-run para simulação sem remoção.",
-      "Ajustado deploy da VPS para não depender de npm instalado no host.",
-      "Primeira versão funcional publicada.",
-      "Site oficial publicado em https://autom8.oslabs.com.br.",
-      "Instalador público disponível em /install.sh.",
-      "Pacotes estáveis passam a ser distribuídos por GitHub Releases."
-    ],
-    "status": "published"
+      "Comando autom8 com menu interativo.",
+      "Módulos doctor, diagnose, update e clean.",
+      "Checagens básicas de security, docker e users.",
+      "Configurações e relatórios iniciais.",
+      "Melhorado comportamento do autom8 clean --dry-run.",
+      "Distribuição estável movida para GitHub Releases.",
+      "install.sh passa a baixar o pacote estável mais recente do GitHub Releases.",
+      "Build do site deixa de publicar pacotes da suíte na VPS.",
+      "Documentação passa a usar fonte única para site, README, roadmap, changelog e help."
+    ]
   }
 ]

--- a/site/src/data/docs.json
+++ b/site/src/data/docs.json
@@ -1,50 +1,114 @@
 [
   {
     "command": "autom8",
-    "description": "Abre o menu interativo principal no terminal."
+    "description": "Abre o menu interativo principal.",
+    "status": "available",
+    "since": "0.1.0",
+    "slug": "menu"
   },
   {
     "command": "autom8 --version",
-    "description": "Mostra a versão instalada do AutoM8."
+    "description": "Mostra a versão instalada.",
+    "status": "available",
+    "since": "0.1.0",
+    "slug": "version"
   },
   {
     "command": "autom8 doctor",
-    "description": "Valida instalação, estrutura, permissões, dependências, PATH, logs e relatórios."
+    "description": "Valida instalação, estrutura, permissões, dependências, PATH, logs e relatórios.",
+    "status": "available",
+    "since": "0.1.0",
+    "slug": "doctor"
   },
   {
     "command": "autom8 diagnose",
-    "description": "Gera um relatório local com informações úteis sobre o sistema."
+    "description": "Gera diagnóstico local do sistema.",
+    "status": "available",
+    "since": "0.1.0",
+    "slug": "diagnose"
   },
   {
     "command": "autom8 update",
-    "description": "Atualiza pacotes do sistema com confirmação e registro de execução."
+    "description": "Atualiza repositórios e pacotes do sistema com confirmação.",
+    "status": "available",
+    "since": "0.1.0",
+    "slug": "update"
   },
   {
     "command": "autom8 clean",
-    "description": "Executa limpeza segura de caches e arquivos dispensáveis."
-  },
-  {
-    "command": "autom8 clean --dry-run",
-    "description": "Simula a limpeza antes de remover qualquer arquivo."
+    "description": "Executa limpeza segura de caches, temporários e arquivos antigos.",
+    "status": "available",
+    "since": "0.1.0",
+    "slug": "clean"
   },
   {
     "command": "autom8 security",
-    "description": "Executa checagens básicas de segurança local."
+    "description": "Executa checagem básica de segurança local.",
+    "status": "available",
+    "since": "0.1.0",
+    "slug": "security"
   },
   {
     "command": "autom8 docker",
-    "description": "Mostra status e informações de uso do Docker quando disponível."
+    "description": "Mostra informações do Docker quando disponível.",
+    "status": "available",
+    "since": "0.1.0",
+    "slug": "docker"
   },
   {
     "command": "autom8 users",
-    "description": "Lista usuários locais relevantes e permissões administrativas."
+    "description": "Lista usuários locais e grupos administrativos.",
+    "status": "available",
+    "since": "0.1.0",
+    "slug": "users"
+  },
+  {
+    "command": "autom8 config",
+    "description": "Permite alterar configurações básicas da suíte.",
+    "status": "available",
+    "since": "0.1.0",
+    "slug": "config"
   },
   {
     "command": "autom8 report",
-    "description": "Lista relatórios gerados pelo AutoM8."
+    "description": "Lista e exporta relatórios gerados.",
+    "status": "available",
+    "since": "0.1.0",
+    "slug": "report"
+  },
+  {
+    "command": "autom8 apps",
+    "description": "Instalação e remoção de aplicativos por catálogo.",
+    "status": "planned",
+    "since": "0.2.0",
+    "slug": "apps"
+  },
+  {
+    "command": "autom8 profiles",
+    "description": "Aplicação de perfis YAML para preparar ambientes.",
+    "status": "planned",
+    "since": "0.2.0",
+    "slug": "profiles"
+  },
+  {
+    "command": "autom8 backup",
+    "description": "Backups simples antes de operações sensíveis.",
+    "status": "planned",
+    "since": "0.3.0",
+    "slug": "backup"
+  },
+  {
+    "command": "autom8 upgrade-distro",
+    "description": "Preparação futura para upgrade de versão da distro.",
+    "status": "planned",
+    "since": "future",
+    "slug": "upgrade-distro"
   },
   {
     "command": "autom8 self-update",
-    "description": "Atualiza o AutoM8 quando houver uma nova versão publicada."
+    "description": "Valida o pacote estável mais recente publicado no GitHub Releases.",
+    "status": "partial",
+    "since": "0.1.0",
+    "slug": "self-update"
   }
 ]

--- a/site/src/data/documentation.json
+++ b/site/src/data/documentation.json
@@ -1,0 +1,458 @@
+{
+  "product": {
+    "name": "AutoM8",
+    "fullName": "AutoM8 - Linux Management Suite",
+    "brand": "AutoM8 by OSLabs",
+    "siteUrl": "https://autom8.oslabs.com.br",
+    "githubRepo": "mdmjunior/autom8",
+    "currentVersion": "0.1.0",
+    "currentDate": "2026-07-06",
+    "summary": "AutoM8 é uma suíte local para preparar, diagnosticar, atualizar e manter ambientes Linux com clareza, logs e controle do usuário.",
+    "positioning": "Automação Linux local, segura e auditável para usuários iniciantes, técnicos e administradores."
+  },
+  "releasePolicy": {
+    "stableSource": "GitHub Releases",
+    "latestPackageUrl": "https://github.com/mdmjunior/autom8/releases/latest/download/autom8-latest.tar.gz",
+    "versionedPackagePattern": "https://github.com/mdmjunior/autom8/releases/download/v{version}/autom8-{version}.tar.gz",
+    "sitePackagePolicy": "A VPS e o build do site não devem hospedar pacotes da suíte. O site publica apenas o instalador e a documentação.",
+    "installerPolicy": "O install.sh deve baixar sempre o pacote estável mais recente publicado no GitHub Releases."
+  },
+  "install": {
+    "command": "curl -fsSL https://autom8.oslabs.com.br/install.sh | bash",
+    "after": [
+      "export PATH=\"/opt/autom8/bin:$PATH\"",
+      "autom8",
+      "autom8 doctor"
+    ],
+    "notes": [
+      "Não execute o instalador diretamente como root.",
+      "O instalador baixa o pacote estável mais recente do GitHub Releases.",
+      "A instalação padrão usa /opt/autom8.",
+      "Ao final, o instalador executa autom8 --version e autom8 doctor."
+    ]
+  },
+  "requirements": [
+    "Usuário comum com permissão de sudo.",
+    "bash, curl, tar, gzip, awk, sed, grep, find e sudo.",
+    "Gerenciador de pacotes suportado: apt, dnf, zypper ou pacman.",
+    "gum é instalado pelo instalador para melhorar a interface interativa.",
+    "Docker, Flatpak, Snap, jq, rsync, nmap e lsof podem ser usados por módulos específicos quando disponíveis."
+  ],
+  "variables": [
+    {
+      "name": "AUTOM8_SITE_URL",
+      "default": "https://autom8.oslabs.com.br",
+      "scope": "install, docs",
+      "description": "URL pública do site oficial do AutoM8."
+    },
+    {
+      "name": "AUTOM8_GITHUB_REPO",
+      "default": "mdmjunior/autom8",
+      "scope": "install, release, self-update",
+      "description": "Repositório GitHub usado para releases estáveis."
+    },
+    {
+      "name": "AUTOM8_PACKAGE_URL",
+      "default": "https://github.com/mdmjunior/autom8/releases/latest/download/autom8-latest.tar.gz",
+      "scope": "install, self-update",
+      "description": "URL do pacote estável usado pelo instalador e validação de atualização."
+    },
+    {
+      "name": "AUTOM8_INSTALL_DIR",
+      "default": "/opt/autom8",
+      "scope": "install, runtime",
+      "description": "Diretório onde a suíte é instalada."
+    },
+    {
+      "name": "AUTOM8_PACKAGE_OUTPUT_DIR",
+      "default": "diretório temporário em /tmp",
+      "scope": "package",
+      "description": "Diretório temporário usado para gerar pacotes antes de publicar uma release."
+    },
+    {
+      "name": "AUTOM8_REPO_DIR",
+      "default": "/opt/oslabs/repos/autom8",
+      "scope": "deploy",
+      "description": "Caminho do repositório na VPS."
+    },
+    {
+      "name": "AUTOM8_BRANCH",
+      "default": "main",
+      "scope": "deploy",
+      "description": "Branch publicada na VPS."
+    },
+    {
+      "name": "AUTOM8_DOMAIN",
+      "default": "https://autom8.oslabs.com.br",
+      "scope": "deploy",
+      "description": "Domínio validado no final do deploy."
+    },
+    {
+      "name": "AUTOM8_SERVICE_NAME",
+      "default": "",
+      "scope": "deploy",
+      "description": "Nome do serviço Docker Swarm que deve ser reiniciado após o build."
+    },
+    {
+      "name": "AUTOM8_RESTART_SERVICE",
+      "default": "1",
+      "scope": "deploy",
+      "description": "Use 0 para validar build sem reiniciar o serviço."
+    }
+  ],
+  "commands": [
+    {
+      "slug": "menu",
+      "command": "autom8",
+      "status": "available",
+      "since": "0.1.0",
+      "summary": "Abre o menu interativo principal.",
+      "details": [
+        "Mostra o dashboard local com distro, permissões, disco, memória, Docker e firewall.",
+        "Permite acessar módulos sem decorar comandos."
+      ],
+      "examples": [
+        "autom8"
+      ]
+    },
+    {
+      "slug": "version",
+      "command": "autom8 --version",
+      "status": "available",
+      "since": "0.1.0",
+      "summary": "Mostra a versão instalada.",
+      "details": [
+        "Lê a versão instalada a partir do arquivo VERSION dentro da suíte."
+      ],
+      "examples": [
+        "autom8 --version"
+      ]
+    },
+    {
+      "slug": "doctor",
+      "command": "autom8 doctor",
+      "status": "available",
+      "since": "0.1.0",
+      "summary": "Valida instalação, estrutura, permissões, dependências, PATH, logs e relatórios.",
+      "details": [
+        "Gera relatório em reports/doctor-<data>.txt.",
+        "Verifica diretórios principais, arquivos obrigatórios, comandos obrigatórios e comandos opcionais.",
+        "Indicado após instalar, atualizar ou mover a suíte."
+      ],
+      "examples": [
+        "autom8 doctor"
+      ]
+    },
+    {
+      "slug": "diagnose",
+      "command": "autom8 diagnose",
+      "status": "available",
+      "since": "0.1.0",
+      "summary": "Gera diagnóstico local do sistema.",
+      "details": [
+        "Coleta informações de sistema, kernel, CPU, memória, disco, rede, DNS, serviços, firewall, portas, Docker, usuários e sessão gráfica.",
+        "Gera relatório em reports/diagnostic-<data>.txt."
+      ],
+      "examples": [
+        "autom8 diagnose"
+      ]
+    },
+    {
+      "slug": "update",
+      "command": "autom8 update",
+      "status": "available",
+      "since": "0.1.0",
+      "summary": "Atualiza repositórios e pacotes do sistema com confirmação.",
+      "details": [
+        "Suporta apt, dnf, zypper e pacman.",
+        "Bloqueia execução em distros não suportadas oficialmente.",
+        "Exige sudo e registra a execução em logs."
+      ],
+      "examples": [
+        "autom8 update",
+        "autom8 update --dry-run"
+      ]
+    },
+    {
+      "slug": "clean",
+      "command": "autom8 clean",
+      "status": "available",
+      "since": "0.1.0",
+      "summary": "Executa limpeza segura de caches, temporários e arquivos antigos.",
+      "details": [
+        "Limpa cache do gerenciador de pacotes conforme a distro.",
+        "Remove temporários antigos em /tmp e /var/tmp.",
+        "Remove logs rotacionados antigos.",
+        "Pode limpar caches seguros de usuários, preservando caches de navegadores conhecidos.",
+        "Suporta simulação com --dry-run."
+      ],
+      "examples": [
+        "autom8 clean",
+        "autom8 clean --dry-run"
+      ]
+    },
+    {
+      "slug": "security",
+      "command": "autom8 security",
+      "status": "available",
+      "since": "0.1.0",
+      "summary": "Executa checagem básica de segurança local.",
+      "details": [
+        "Mostra status de firewall conhecido.",
+        "Lista portas em escuta.",
+        "Verifica status básico de SSH."
+      ],
+      "examples": [
+        "autom8 security"
+      ]
+    },
+    {
+      "slug": "docker",
+      "command": "autom8 docker",
+      "status": "available",
+      "since": "0.1.0",
+      "summary": "Mostra informações do Docker quando disponível.",
+      "details": [
+        "Mostra versão do Docker.",
+        "Lista containers em execução.",
+        "Mostra uso de disco do Docker."
+      ],
+      "examples": [
+        "autom8 docker"
+      ]
+    },
+    {
+      "slug": "users",
+      "command": "autom8 users",
+      "status": "available",
+      "since": "0.1.0",
+      "summary": "Lista usuários locais e grupos administrativos.",
+      "details": [
+        "Mostra usuários com login permitido.",
+        "Mostra grupos sudo, wheel e admin quando existem.",
+        "Ações de bloqueio, shell e sudo ficam para versão futura."
+      ],
+      "examples": [
+        "autom8 users"
+      ]
+    },
+    {
+      "slug": "config",
+      "command": "autom8 config",
+      "status": "available",
+      "since": "0.1.0",
+      "summary": "Permite alterar configurações básicas da suíte.",
+      "details": [
+        "Permite selecionar idioma.",
+        "Permite selecionar modo padrão.",
+        "Permite selecionar nível de limpeza padrão.",
+        "Permite visualizar a configuração atual."
+      ],
+      "examples": [
+        "autom8 config"
+      ]
+    },
+    {
+      "slug": "report",
+      "command": "autom8 report",
+      "status": "available",
+      "since": "0.1.0",
+      "summary": "Lista e exporta relatórios gerados.",
+      "details": [
+        "Lista arquivos em reports/.",
+        "Pode exportar relatórios em tar.gz pelo menu.",
+        "Também aceita autom8 report export para exportar logs e relatórios."
+      ],
+      "examples": [
+        "autom8 report",
+        "autom8 report export"
+      ]
+    },
+    {
+      "slug": "apps",
+      "command": "autom8 apps",
+      "status": "planned",
+      "since": "0.2.0",
+      "summary": "Instalação e remoção de aplicativos por catálogo.",
+      "details": [
+        "Na versão 0.1.0, o módulo existe como placeholder e será implementado na 0.2.0."
+      ],
+      "examples": [
+        "autom8 apps"
+      ]
+    },
+    {
+      "slug": "profiles",
+      "command": "autom8 profiles",
+      "status": "planned",
+      "since": "0.2.0",
+      "summary": "Aplicação de perfis YAML para preparar ambientes.",
+      "details": [
+        "Na versão 0.1.0, o módulo existe como placeholder e será implementado na 0.2.0."
+      ],
+      "examples": [
+        "autom8 profiles"
+      ]
+    },
+    {
+      "slug": "backup",
+      "command": "autom8 backup",
+      "status": "planned",
+      "since": "0.3.0",
+      "summary": "Backups simples antes de operações sensíveis.",
+      "details": [
+        "Na versão 0.1.0, o módulo existe como placeholder e será implementado na 0.3.0."
+      ],
+      "examples": [
+        "autom8 backup"
+      ]
+    },
+    {
+      "slug": "upgrade-distro",
+      "command": "autom8 upgrade-distro",
+      "status": "planned",
+      "since": "future",
+      "summary": "Preparação futura para upgrade de versão da distro.",
+      "details": [
+        "Na versão 0.1.0, o módulo apenas informa que será implementado em versão futura."
+      ],
+      "examples": [
+        "autom8 upgrade-distro"
+      ]
+    },
+    {
+      "slug": "self-update",
+      "command": "autom8 self-update",
+      "status": "partial",
+      "since": "0.1.0",
+      "summary": "Valida o pacote estável mais recente publicado no GitHub Releases.",
+      "details": [
+        "Na versão atual, baixa e valida o tar.gz estável quando o usuário confirma.",
+        "Atualização automática com rollback será implementada em versão futura."
+      ],
+      "examples": [
+        "autom8 self-update"
+      ]
+    }
+  ],
+  "modules": [
+    {
+      "name": "Doctor",
+      "slug": "doctor",
+      "status": "available",
+      "version": "0.1.0",
+      "command": "autom8 doctor",
+      "description": "Valida instalação, estrutura, permissões, dependências, PATH, logs e relatórios."
+    },
+    {
+      "name": "Diagnóstico",
+      "slug": "diagnose",
+      "status": "available",
+      "version": "0.1.0",
+      "command": "autom8 diagnose",
+      "description": "Gera relatório local com informações de sistema, hardware, rede, firewall, Docker e usuários."
+    },
+    {
+      "name": "Atualização do Sistema",
+      "slug": "update",
+      "status": "available",
+      "version": "0.1.0",
+      "command": "autom8 update",
+      "description": "Atualiza pacotes usando apt, dnf, zypper ou pacman, com confirmação e logs."
+    },
+    {
+      "name": "Limpeza",
+      "slug": "clean",
+      "status": "available",
+      "version": "0.1.0",
+      "command": "autom8 clean",
+      "description": "Executa limpeza segura e suporta simulação com --dry-run."
+    },
+    {
+      "name": "Segurança",
+      "slug": "security",
+      "status": "available",
+      "version": "0.1.0",
+      "command": "autom8 security",
+      "description": "Mostra firewall, portas em escuta e status básico de SSH."
+    },
+    {
+      "name": "Docker",
+      "slug": "docker",
+      "status": "available",
+      "version": "0.1.0",
+      "command": "autom8 docker",
+      "description": "Mostra versão, containers em execução e uso de disco do Docker quando disponível."
+    },
+    {
+      "name": "Usuários",
+      "slug": "users",
+      "status": "available",
+      "version": "0.1.0",
+      "command": "autom8 users",
+      "description": "Lista usuários com login permitido e grupos administrativos."
+    },
+    {
+      "name": "Configurações",
+      "slug": "config",
+      "status": "available",
+      "version": "0.1.0",
+      "command": "autom8 config",
+      "description": "Permite ajustar idioma, modo padrão, nível de limpeza e visualizar configuração."
+    },
+    {
+      "name": "Relatórios",
+      "slug": "report",
+      "status": "available",
+      "version": "0.1.0",
+      "command": "autom8 report",
+      "description": "Lista e exporta relatórios gerados pela suíte."
+    },
+    {
+      "name": "Apps",
+      "slug": "apps",
+      "status": "planned",
+      "version": "0.2.0",
+      "command": "autom8 apps",
+      "description": "Instalação e remoção de aplicativos por catálogo. Planejado para 0.2.0."
+    },
+    {
+      "name": "Perfis",
+      "slug": "profiles",
+      "status": "planned",
+      "version": "0.2.0",
+      "command": "autom8 profiles",
+      "description": "Perfis YAML para preparar ambientes. Planejado para 0.2.0."
+    },
+    {
+      "name": "Backup",
+      "slug": "backup",
+      "status": "planned",
+      "version": "0.3.0",
+      "command": "autom8 backup",
+      "description": "Backups simples antes de operações sensíveis. Planejado para 0.3.0."
+    }
+  ],
+  "troubleshooting": [
+    {
+      "title": "Comando autom8 não encontrado",
+      "solution": "Execute export PATH=\"/opt/autom8/bin:$PATH\" ou abra uma nova sessão de terminal após a instalação."
+    },
+    {
+      "title": "Instalador bloqueou execução como root",
+      "solution": "Execute o instalador com um usuário comum que tenha permissão de sudo."
+    },
+    {
+      "title": "Doctor encontrou comandos opcionais ausentes",
+      "solution": "Comandos opcionais podem ser instalados conforme necessidade. Falhas críticas aparecem separadas de avisos."
+    },
+    {
+      "title": "Distro não suportada oficialmente",
+      "solution": "Na versão atual, ações administrativas ficam bloqueadas e diagnóstico permanece disponível."
+    },
+    {
+      "title": "GitHub Release sem pacote latest",
+      "solution": "Publique a release estável com scripts/release-stable.sh a partir da branch main após merge."
+    }
+  ]
+}

--- a/site/src/data/modules.json
+++ b/site/src/data/modules.json
@@ -1,47 +1,98 @@
 [
   {
-    "name": "Atualização do Sistema",
-    "slug": "update",
-    "description": "Atualize repositórios e pacotes com confirmação, registro em log e foco em previsibilidade."
-  },
-  {
-    "name": "Limpeza",
-    "slug": "clean",
-    "description": "Remova caches e arquivos dispensáveis com modos seguros, simulação prévia e proteção contra exclusões perigosas."
-  },
-  {
-    "name": "Apps",
-    "slug": "apps",
-    "description": "Prepare a instalação e remoção de aplicativos por categorias, usando fontes adequadas para cada distribuição."
-  },
-  {
-    "name": "Perfis",
-    "slug": "profiles",
-    "description": "Aplique conjuntos de ferramentas para usos como desenvolvimento, DevOps, design, jogos, administração e servidores."
-  },
-  {
-    "name": "Backup",
-    "slug": "backup",
-    "description": "Crie cópias simples de configurações e arquivos importantes antes de operações sensíveis."
+    "name": "Doctor",
+    "slug": "doctor",
+    "status": "available",
+    "version": "0.1.0",
+    "command": "autom8 doctor",
+    "description": "Valida instalação, estrutura, permissões, dependências, PATH, logs e relatórios."
   },
   {
     "name": "Diagnóstico",
     "slug": "diagnose",
-    "description": "Gere relatórios locais com informações de sistema, hardware, rede, Docker, firewall, usuários e serviços."
+    "status": "available",
+    "version": "0.1.0",
+    "command": "autom8 diagnose",
+    "description": "Gera relatório local com informações de sistema, hardware, rede, firewall, Docker e usuários."
+  },
+  {
+    "name": "Atualização do Sistema",
+    "slug": "update",
+    "status": "available",
+    "version": "0.1.0",
+    "command": "autom8 update",
+    "description": "Atualiza pacotes usando apt, dnf, zypper ou pacman, com confirmação e logs."
+  },
+  {
+    "name": "Limpeza",
+    "slug": "clean",
+    "status": "available",
+    "version": "0.1.0",
+    "command": "autom8 clean",
+    "description": "Executa limpeza segura e suporta simulação com --dry-run."
   },
   {
     "name": "Segurança",
     "slug": "security",
-    "description": "Revise portas abertas, firewall, SSH, usuários administrativos, atualizações pendentes e serviços expostos."
+    "status": "available",
+    "version": "0.1.0",
+    "command": "autom8 security",
+    "description": "Mostra firewall, portas em escuta e status básico de SSH."
   },
   {
     "name": "Docker",
     "slug": "docker",
-    "description": "Consulte containers, imagens, volumes e consumo para manter ambientes Docker mais fáceis de revisar."
+    "status": "available",
+    "version": "0.1.0",
+    "command": "autom8 docker",
+    "description": "Mostra versão, containers em execução e uso de disco do Docker quando disponível."
   },
   {
     "name": "Usuários",
     "slug": "users",
-    "description": "Liste usuários com login permitido, shells, diretórios home, grupos e permissões administrativas."
+    "status": "available",
+    "version": "0.1.0",
+    "command": "autom8 users",
+    "description": "Lista usuários com login permitido e grupos administrativos."
+  },
+  {
+    "name": "Configurações",
+    "slug": "config",
+    "status": "available",
+    "version": "0.1.0",
+    "command": "autom8 config",
+    "description": "Permite ajustar idioma, modo padrão, nível de limpeza e visualizar configuração."
+  },
+  {
+    "name": "Relatórios",
+    "slug": "report",
+    "status": "available",
+    "version": "0.1.0",
+    "command": "autom8 report",
+    "description": "Lista e exporta relatórios gerados pela suíte."
+  },
+  {
+    "name": "Apps",
+    "slug": "apps",
+    "status": "planned",
+    "version": "0.2.0",
+    "command": "autom8 apps",
+    "description": "Instalação e remoção de aplicativos por catálogo. Planejado para 0.2.0."
+  },
+  {
+    "name": "Perfis",
+    "slug": "profiles",
+    "status": "planned",
+    "version": "0.2.0",
+    "command": "autom8 profiles",
+    "description": "Perfis YAML para preparar ambientes. Planejado para 0.2.0."
+  },
+  {
+    "name": "Backup",
+    "slug": "backup",
+    "status": "planned",
+    "version": "0.3.0",
+    "command": "autom8 backup",
+    "description": "Backups simples antes de operações sensíveis. Planejado para 0.3.0."
   }
 ]

--- a/site/src/data/roadmap.json
+++ b/site/src/data/roadmap.json
@@ -12,7 +12,8 @@
       "Diagnóstico",
       "Update básico",
       "Limpeza segura",
-      "Site inicial"
+      "Site inicial",
+      "Distribuição estável via GitHub Releases"
     ]
   },
   {
@@ -48,7 +49,8 @@
       "Documentação completa",
       "Changelog versionado",
       "Instalação estável",
-      "Rollback documentado"
+      "Rollback documentado",
+      "Pipeline de release estável documentado"
     ]
   }
 ]

--- a/site/src/data/roadmap.json
+++ b/site/src/data/roadmap.json
@@ -1,56 +1,62 @@
 [
   {
     "version": "0.1.0",
-    "title": "Base funcional",
+    "title": "Base funcional e release estável",
     "items": [
-      "Estrutura /opt/autom8",
-      "Instalador install.sh",
-      "Comando autom8",
-      "Detecção de distro",
-      "Logs próprios",
-      "Menu com gum",
-      "Diagnóstico",
-      "Update básico",
-      "Limpeza segura",
-      "Site inicial",
-      "Distribuição estável via GitHub Releases"
+      "Estrutura /opt/autom8.",
+      "Instalador install.sh.",
+      "Comando autom8.",
+      "Detecção de distro e gerenciador de pacotes.",
+      "Logs próprios.",
+      "Menu interativo com gum.",
+      "Doctor.",
+      "Diagnóstico.",
+      "Update básico.",
+      "Limpeza segura com dry-run.",
+      "Checagens básicas de segurança.",
+      "Docker status.",
+      "Usuários.",
+      "Configurações.",
+      "Relatórios.",
+      "Site oficial.",
+      "Distribuição estável via GitHub Releases."
     ]
   },
   {
     "version": "0.2.0",
     "title": "Apps e perfis",
     "items": [
-      "Catálogo YAML",
-      "Instalação e remoção de apps",
-      "Perfis YAML",
-      "Modo mínimo seguro",
-      "Modo completo",
-      "Seleção individual de apps",
-      "Flatpak e Flathub"
+      "Catálogo YAML.",
+      "Instalação e remoção de apps.",
+      "Perfis YAML.",
+      "Modo mínimo seguro.",
+      "Modo completo.",
+      "Seleção individual de apps.",
+      "Flatpak e Flathub."
     ]
   },
   {
     "version": "0.3.0",
-    "title": "Segurança, usuários e Docker",
+    "title": "Operação, backups e segurança expandida",
     "items": [
-      "Módulo security",
-      "Módulo users",
-      "Módulo docker",
-      "Relatórios exportáveis",
-      "Backups críticos",
-      "Rollback parcial"
+      "Backup funcional.",
+      "Rollback parcial.",
+      "Security expandido.",
+      "Users com ações administrativas.",
+      "Docker com manutenção orientada.",
+      "Relatórios exportáveis mais completos."
     ]
   },
   {
     "version": "1.0.0",
-    "title": "Primeira versão estável",
+    "title": "Primeira versão estável completa",
     "items": [
-      "Suporte testado nas distros oficiais",
-      "Documentação completa",
-      "Changelog versionado",
-      "Instalação estável",
-      "Rollback documentado",
-      "Pipeline de release estável documentado"
+      "Suporte testado nas distros oficiais.",
+      "Documentação completa.",
+      "Changelog versionado.",
+      "Instalação estável.",
+      "Self-update com rollback documentado.",
+      "Pipeline de release estável documentado."
     ]
   }
 ]

--- a/site/src/pages/docs.astro
+++ b/site/src/pages/docs.astro
@@ -1,28 +1,124 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
-import docs from '../data/docs.json';
+import documentation from '../data/documentation.json';
+
+const availableCommands = documentation.commands.filter((item) => item.status === 'available');
+const partialCommands = documentation.commands.filter((item) => item.status === 'partial');
+const plannedCommands = documentation.commands.filter((item) => item.status === 'planned');
+
+const statusLabel = {
+  available: 'Disponível',
+  partial: 'Parcial',
+  planned: 'Planejado'
+};
+
+const statusClass = {
+  available: 'autom8-status-badge',
+  partial: 'autom8-version-badge',
+  planned: 'autom8-card-kicker'
+};
 ---
 
 <BaseLayout
   title="Docs · AutoM8"
-  description="Documentação inicial dos comandos principais do AutoM8 para Linux desktop."
+  description="Documentação oficial do AutoM8: instalação, comandos, módulos, releases, variáveis e solução de problemas."
 >
   <section class="site-page-hero">
     <div class="site-page-hero__inner">
       <p class="page-eyebrow">Documentação</p>
-      <h1 class="page-title">Comandos claros para tarefas reais.</h1>
+      <h1 class="page-title">Documentação oficial do AutoM8.</h1>
       <p class="page-description">
-        A primeira versão do AutoM8 prioriza comandos essenciais, validação local e relatórios simples para manter o usuário no controle.
+        Instale, valide, diagnostique e mantenha ambientes Linux com comandos claros, documentação versionada e distribuição estável via GitHub Releases.
       </p>
+
+      <div class="page-actions">
+        <a href="#instalacao" class="autom8-primary-button">Instalar</a>
+        <a href="#comandos" class="autom8-secondary-button">Ver comandos</a>
+      </div>
     </div>
   </section>
 
-  <section class="site-page-section">
+  <section id="visao-geral" class="site-page-section">
     <div class="site-page-section__inner">
       <div class="section-heading">
-        <p class="section-eyebrow text-blue-300">Referência rápida</p>
-        <h2>Comandos principais</h2>
-        <p>Use esta tabela como ponto de partida para instalação, diagnóstico, limpeza, segurança e relatórios.</p>
+        <p class="section-eyebrow text-blue-300">Visão geral</p>
+        <h2>{documentation.product.fullName}</h2>
+        <p>{documentation.product.summary}</p>
+      </div>
+
+      <div class="autom8-content-grid autom8-content-grid--three">
+        <article class="autom8-standard-card">
+          <span class="autom8-card-kicker">local</span>
+          <h3>Execução local</h3>
+          <p>O AutoM8 roda na própria máquina Linux e mantém relatórios, logs e configurações dentro da instalação local.</p>
+        </article>
+
+        <article class="autom8-standard-card">
+          <span class="autom8-card-kicker">controle</span>
+          <h3>Ações revisáveis</h3>
+          <p>Comandos administrativos exigem sudo, usam confirmações quando necessário e registram ações em logs.</p>
+        </article>
+
+        <article class="autom8-standard-card">
+          <span class="autom8-card-kicker">release</span>
+          <h3>Pacote estável</h3>
+          <p>O instalador baixa a última versão estável publicada no GitHub Releases, não pacotes locais ou da VPS.</p>
+        </article>
+      </div>
+    </div>
+  </section>
+
+  <section id="instalacao" class="site-page-section">
+    <div class="site-page-section__inner">
+      <div class="section-heading">
+        <p class="section-eyebrow text-green-300">Instalação</p>
+        <h2>Instale com um comando.</h2>
+        <p>Execute com usuário comum que tenha permissão de sudo. Não execute diretamente como root.</p>
+      </div>
+
+      <div class="autom8-command-panel">
+        <div class="autom8-command-panel__header">
+          <span>terminal</span>
+          <strong>install.sh</strong>
+        </div>
+        <pre><code>{documentation.install.command}</code></pre>
+      </div>
+
+      <div class="autom8-content-grid autom8-content-grid--three mt-8">
+        {documentation.install.notes.map((note) => (
+          <article class="autom8-standard-card">
+            <span class="autom8-card-kicker">nota</span>
+            <p>{note}</p>
+          </article>
+        ))}
+      </div>
+    </div>
+  </section>
+
+  <section id="requisitos" class="site-page-section">
+    <div class="site-page-section__inner">
+      <div class="section-heading">
+        <p class="section-eyebrow text-blue-300">Requisitos</p>
+        <h2>Base necessária</h2>
+        <p>O instalador prepara dependências comuns, mas estes pontos ajudam a entender o ambiente esperado.</p>
+      </div>
+
+      <div class="autom8-timeline">
+        {documentation.requirements.map((item) => (
+          <article class="autom8-release-card">
+            <p>{item}</p>
+          </article>
+        ))}
+      </div>
+    </div>
+  </section>
+
+  <section id="comandos" class="site-page-section">
+    <div class="site-page-section__inner">
+      <div class="section-heading">
+        <p class="section-eyebrow text-green-300">CLI</p>
+        <h2>Comandos disponíveis</h2>
+        <p>Estes comandos estão disponíveis na versão atual da suíte.</p>
       </div>
 
       <div class="autom8-table-card">
@@ -30,38 +126,129 @@ import docs from '../data/docs.json';
           <thead>
             <tr>
               <th>Comando</th>
+              <th>Status</th>
               <th>Descrição</th>
             </tr>
           </thead>
           <tbody>
-            {docs.map((item) => (
+            {availableCommands.map((item) => (
               <tr>
                 <td><code>{item.command}</code></td>
-                <td>{item.description}</td>
+                <td><span class={statusClass[item.status]}>{statusLabel[item.status]}</span></td>
+                <td>{item.summary}</td>
               </tr>
             ))}
           </tbody>
         </table>
       </div>
 
-      <div class="autom8-content-grid autom8-content-grid--three mt-8">
-        <article class="autom8-standard-card">
-          <span class="autom8-card-kicker">check</span>
-          <h3>Valide primeiro</h3>
-          <p>Comece por <code>autom8 doctor</code> para conferir instalação, permissões e dependências.</p>
-        </article>
+      <div class="section-heading mt-12">
+        <h2>Comandos parciais e planejados</h2>
+        <p>Esses comandos já aparecem no menu ou na CLI, mas ainda não representam funcionalidade completa.</p>
+      </div>
 
-        <article class="autom8-standard-card">
-          <span class="autom8-card-kicker">dry</span>
-          <h3>Simule antes</h3>
-          <p>Use <code>autom8 clean --dry-run</code> para revisar ações antes de remover arquivos.</p>
-        </article>
+      <div class="autom8-content-grid autom8-content-grid--three">
+        {[...partialCommands, ...plannedCommands].map((item) => (
+          <article class="autom8-standard-card">
+            <span class={statusClass[item.status]}>{statusLabel[item.status]}</span>
+            <h3><code>{item.command}</code></h3>
+            <p>{item.summary}</p>
+          </article>
+        ))}
+      </div>
+    </div>
+  </section>
 
-        <article class="autom8-standard-card">
-          <span class="autom8-card-kicker">logs</span>
-          <h3>Gere relatórios</h3>
-          <p>Os relatórios ficam locais e ajudam a revisar o estado da máquina com mais segurança.</p>
-        </article>
+  <section id="modulos" class="site-page-section">
+    <div class="site-page-section__inner">
+      <div class="section-heading">
+        <p class="section-eyebrow text-blue-300">Módulos</p>
+        <h2>Módulos da suíte</h2>
+        <p>Cada módulo tem status explícito para evitar prometer funcionalidades ainda planejadas.</p>
+      </div>
+
+      <div class="autom8-content-grid autom8-content-grid--three">
+        {documentation.modules.map((item) => (
+          <article class="autom8-standard-card autom8-standard-card--module">
+            <div class="module-card-top">
+              <span class={statusClass[item.status]}>{statusLabel[item.status]}</span>
+              <span class="module-command">{item.command}</span>
+            </div>
+            <h3>{item.name}</h3>
+            <p>{item.description}</p>
+          </article>
+        ))}
+      </div>
+    </div>
+  </section>
+
+  <section id="variaveis" class="site-page-section">
+    <div class="site-page-section__inner">
+      <div class="section-heading">
+        <p class="section-eyebrow text-green-300">Variáveis</p>
+        <h2>Configuração por ambiente</h2>
+        <p>Essas variáveis controlam instalação, release, empacotamento e deploy.</p>
+      </div>
+
+      <div class="autom8-table-card">
+        <table class="autom8-data-table">
+          <thead>
+            <tr>
+              <th>Variável</th>
+              <th>Padrão</th>
+              <th>Escopo</th>
+              <th>Descrição</th>
+            </tr>
+          </thead>
+          <tbody>
+            {documentation.variables.map((item) => (
+              <tr>
+                <td><code>{item.name}</code></td>
+                <td><code>{item.default}</code></td>
+                <td>{item.scope}</td>
+                <td>{item.description}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </section>
+
+  <section id="release" class="site-page-section">
+    <div class="site-page-section__inner">
+      <div class="section-heading">
+        <p class="section-eyebrow text-blue-300">Release estável</p>
+        <h2>Distribuição via GitHub Releases</h2>
+        <p>{documentation.releasePolicy.sitePackagePolicy}</p>
+      </div>
+
+      <div class="autom8-command-panel">
+        <div class="autom8-command-panel__header">
+          <span>latest package</span>
+          <strong>GitHub Releases</strong>
+        </div>
+        <pre><code>{documentation.releasePolicy.latestPackageUrl}</code></pre>
+      </div>
+    </div>
+  </section>
+
+  <section id="troubleshooting" class="site-page-section">
+    <div class="site-page-section__inner">
+      <div class="section-heading">
+        <p class="section-eyebrow text-green-300">Troubleshooting</p>
+        <h2>Problemas comuns</h2>
+        <p>Primeiros pontos de verificação quando algo não sair como esperado.</p>
+      </div>
+
+      <div class="autom8-content-grid autom8-content-grid--three">
+        {documentation.troubleshooting.map((item) => (
+          <article class="autom8-standard-card">
+            <span class="autom8-card-kicker">fix</span>
+            <h3>{item.title}</h3>
+            <p>{item.solution}</p>
+          </article>
+        ))}
       </div>
     </div>
   </section>

--- a/site/src/pages/modules.astro
+++ b/site/src/pages/modules.astro
@@ -1,18 +1,30 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
 import modules from '../data/modules.json';
+
+const statusLabel = {
+  available: 'Disponível',
+  partial: 'Parcial',
+  planned: 'Planejado'
+};
+
+const statusClass = {
+  available: 'autom8-status-badge',
+  partial: 'autom8-version-badge',
+  planned: 'autom8-card-kicker'
+};
 ---
 
 <BaseLayout
   title="Módulos · AutoM8"
-  description="Conheça os módulos do AutoM8 para atualização, limpeza, apps, perfis, backup, diagnóstico, segurança, Docker e usuários."
+  description="Conheça os módulos disponíveis, parciais e planejados do AutoM8."
 >
   <section class="site-page-hero">
     <div class="site-page-hero__inner">
       <p class="page-eyebrow">Módulos</p>
       <h1 class="page-title">Uma suíte modular para manter o Linux em ordem.</h1>
       <p class="page-description">
-        Cada módulo resolve uma tarefa específica e mantém o AutoM8 simples de evoluir, testar e auditar.
+        Cada módulo resolve uma tarefa específica e possui status explícito para separar o que já está disponível do que está planejado.
       </p>
     </div>
   </section>
@@ -29,8 +41,8 @@ import modules from '../data/modules.json';
         {modules.map((item) => (
           <article class="autom8-standard-card autom8-standard-card--module">
             <div class="module-card-top">
-              <span class="autom8-card-kicker">{item.slug}</span>
-              <span class="module-command">autom8 {item.slug}</span>
+              <span class={statusClass[item.status]}>{statusLabel[item.status]}</span>
+              <span class="module-command">{item.command}</span>
             </div>
             <h3>{item.name}</h3>
             <p>{item.description}</p>

--- a/suite/bin/autom8
+++ b/suite/bin/autom8
@@ -17,6 +17,8 @@ source "$AUTOM8_ROOT/core/detect.sh"
 source "$AUTOM8_ROOT/core/sudo.sh"
 # shellcheck source=/dev/null
 source "$AUTOM8_ROOT/core/summary.sh"
+# shellcheck source=/dev/null
+source "$AUTOM8_ROOT/core/help.sh"
 
 # shellcheck source=/dev/null
 source "$AUTOM8_ROOT/modules/diagnose.sh"
@@ -48,31 +50,8 @@ source "$AUTOM8_ROOT/modules/report.sh"
 source "$AUTOM8_ROOT/modules/self_update.sh"
 
 autom8_usage() {
-  cat <<EOF_USAGE
-AutoM8 - Linux Management Suite
-
-Uso:
-  autom8
-  autom8 update [--dry-run]
-  autom8 upgrade-distro
-  autom8 clean [--dry-run]
-  autom8 apps
-  autom8 profiles
-  autom8 backup
-  autom8 diagnose
-  autom8 doctor
-  autom8 security
-  autom8 docker
-  autom8 users
-  autom8 config
-  autom8 report
-  autom8 report export
-  autom8 self-update
-  autom8 --version
-  autom8 --help
-EOF_USAGE
+  autom8_help_index
 }
-
 autom8_dashboard() {
   autom8_title "AutoM8 Dashboard"
 
@@ -195,8 +174,16 @@ main() {
       echo "AutoM8 $AUTOM8_VERSION"
       exit 0
       ;;
-    --help|-h|help)
+    --help|-h)
       autom8_usage
+      exit 0
+      ;;
+    help)
+      if [[ -n "${2:-}" ]]; then
+        autom8_help_command "$2"
+      else
+        autom8_help_index
+      fi
       exit 0
       ;;
   esac

--- a/suite/core/help.sh
+++ b/suite/core/help.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+autom8_help_index() {
+  local help_file="$AUTOM8_ROOT/docs/help.txt"
+
+  if [[ -f "$help_file" ]]; then
+    cat "$help_file"
+    return 0
+  fi
+
+  cat <<'EOF_FALLBACK'
+AutoM8 - Linux Management Suite
+
+Uso:
+  autom8
+  autom8 help
+  autom8 help <comando>
+  autom8 --version
+
+A documentação local não foi encontrada.
+Execute autom8 doctor para validar a instalação.
+EOF_FALLBACK
+}
+
+autom8_help_command() {
+  local command_name="${1:-}"
+  local help_dir="$AUTOM8_ROOT/docs/help"
+  local help_file=""
+
+  case "$command_name" in
+    ""|help|--help|-h)
+      autom8_help_index
+      return 0
+      ;;
+    --version|-v|version)
+      help_file="$help_dir/version.txt"
+      ;;
+    upgrade-distro)
+      help_file="$help_dir/upgrade-distro.txt"
+      ;;
+    self-update)
+      help_file="$help_dir/self-update.txt"
+      ;;
+    *)
+      help_file="$help_dir/${command_name}.txt"
+      ;;
+  esac
+
+  if [[ -f "$help_file" ]]; then
+    cat "$help_file"
+    return 0
+  fi
+
+  autom8_warn_ui "Ajuda específica não encontrada para: $command_name"
+  echo
+  autom8_help_index
+}

--- a/suite/docs/help.txt
+++ b/suite/docs/help.txt
@@ -1,0 +1,39 @@
+AutoM8 - Linux Management Suite
+
+AutoM8 é uma suíte local para preparar, diagnosticar, atualizar e manter ambientes Linux com clareza, logs e controle do usuário.
+
+Uso:
+  autom8
+  autom8 help
+  autom8 help <comando>
+  autom8 --version
+
+Comandos disponíveis:
+  autom8                   Abre o menu interativo principal.
+  autom8 --version         Mostra a versão instalada.
+  autom8 doctor            Valida instalação, estrutura, permissões, dependências, PATH, logs e relatórios.
+  autom8 diagnose          Gera diagnóstico local do sistema.
+  autom8 update            Atualiza repositórios e pacotes do sistema com confirmação.
+  autom8 clean             Executa limpeza segura de caches, temporários e arquivos antigos.
+  autom8 security          Executa checagem básica de segurança local.
+  autom8 docker            Mostra informações do Docker quando disponível.
+  autom8 users             Lista usuários locais e grupos administrativos.
+  autom8 config            Permite alterar configurações básicas da suíte.
+  autom8 report            Lista e exporta relatórios gerados.
+
+Comandos parciais:
+  autom8 self-update       Valida o pacote estável mais recente publicado no GitHub Releases.
+
+Comandos planejados:
+  autom8 apps              Instalação e remoção de aplicativos por catálogo.
+  autom8 profiles          Aplicação de perfis YAML para preparar ambientes.
+  autom8 backup            Backups simples antes de operações sensíveis.
+  autom8 upgrade-distro    Preparação futura para upgrade de versão da distro.
+
+Ajuda por comando:
+  autom8 help doctor
+  autom8 help clean
+  autom8 help update
+
+Site: https://autom8.oslabs.com.br
+Release estável: https://github.com/mdmjunior/autom8/releases/latest/download/autom8-latest.tar.gz

--- a/suite/docs/help/apps.txt
+++ b/suite/docs/help/apps.txt
@@ -1,0 +1,12 @@
+AutoM8 help: autom8 apps
+
+Status: planned
+Desde: 0.2.0
+
+Instalação e remoção de aplicativos por catálogo.
+
+Detalhes:
+- Na versão 0.1.0, o módulo existe como placeholder e será implementado na 0.2.0.
+
+Exemplos:
+  autom8 apps

--- a/suite/docs/help/backup.txt
+++ b/suite/docs/help/backup.txt
@@ -1,0 +1,12 @@
+AutoM8 help: autom8 backup
+
+Status: planned
+Desde: 0.3.0
+
+Backups simples antes de operações sensíveis.
+
+Detalhes:
+- Na versão 0.1.0, o módulo existe como placeholder e será implementado na 0.3.0.
+
+Exemplos:
+  autom8 backup

--- a/suite/docs/help/clean.txt
+++ b/suite/docs/help/clean.txt
@@ -1,0 +1,17 @@
+AutoM8 help: autom8 clean
+
+Status: available
+Desde: 0.1.0
+
+Executa limpeza segura de caches, temporários e arquivos antigos.
+
+Detalhes:
+- Limpa cache do gerenciador de pacotes conforme a distro.
+- Remove temporários antigos em /tmp e /var/tmp.
+- Remove logs rotacionados antigos.
+- Pode limpar caches seguros de usuários, preservando caches de navegadores conhecidos.
+- Suporta simulação com --dry-run.
+
+Exemplos:
+  autom8 clean
+  autom8 clean --dry-run

--- a/suite/docs/help/config.txt
+++ b/suite/docs/help/config.txt
@@ -1,0 +1,15 @@
+AutoM8 help: autom8 config
+
+Status: available
+Desde: 0.1.0
+
+Permite alterar configurações básicas da suíte.
+
+Detalhes:
+- Permite selecionar idioma.
+- Permite selecionar modo padrão.
+- Permite selecionar nível de limpeza padrão.
+- Permite visualizar a configuração atual.
+
+Exemplos:
+  autom8 config

--- a/suite/docs/help/diagnose.txt
+++ b/suite/docs/help/diagnose.txt
@@ -1,0 +1,13 @@
+AutoM8 help: autom8 diagnose
+
+Status: available
+Desde: 0.1.0
+
+Gera diagnóstico local do sistema.
+
+Detalhes:
+- Coleta informações de sistema, kernel, CPU, memória, disco, rede, DNS, serviços, firewall, portas, Docker, usuários e sessão gráfica.
+- Gera relatório em reports/diagnostic-<data>.txt.
+
+Exemplos:
+  autom8 diagnose

--- a/suite/docs/help/docker.txt
+++ b/suite/docs/help/docker.txt
@@ -1,0 +1,14 @@
+AutoM8 help: autom8 docker
+
+Status: available
+Desde: 0.1.0
+
+Mostra informações do Docker quando disponível.
+
+Detalhes:
+- Mostra versão do Docker.
+- Lista containers em execução.
+- Mostra uso de disco do Docker.
+
+Exemplos:
+  autom8 docker

--- a/suite/docs/help/doctor.txt
+++ b/suite/docs/help/doctor.txt
@@ -1,0 +1,14 @@
+AutoM8 help: autom8 doctor
+
+Status: available
+Desde: 0.1.0
+
+Valida instalação, estrutura, permissões, dependências, PATH, logs e relatórios.
+
+Detalhes:
+- Gera relatório em reports/doctor-<data>.txt.
+- Verifica diretórios principais, arquivos obrigatórios, comandos obrigatórios e comandos opcionais.
+- Indicado após instalar, atualizar ou mover a suíte.
+
+Exemplos:
+  autom8 doctor

--- a/suite/docs/help/menu.txt
+++ b/suite/docs/help/menu.txt
@@ -1,0 +1,13 @@
+AutoM8 help: autom8
+
+Status: available
+Desde: 0.1.0
+
+Abre o menu interativo principal.
+
+Detalhes:
+- Mostra o dashboard local com distro, permissões, disco, memória, Docker e firewall.
+- Permite acessar módulos sem decorar comandos.
+
+Exemplos:
+  autom8

--- a/suite/docs/help/profiles.txt
+++ b/suite/docs/help/profiles.txt
@@ -1,0 +1,12 @@
+AutoM8 help: autom8 profiles
+
+Status: planned
+Desde: 0.2.0
+
+Aplicação de perfis YAML para preparar ambientes.
+
+Detalhes:
+- Na versão 0.1.0, o módulo existe como placeholder e será implementado na 0.2.0.
+
+Exemplos:
+  autom8 profiles

--- a/suite/docs/help/report.txt
+++ b/suite/docs/help/report.txt
@@ -1,0 +1,15 @@
+AutoM8 help: autom8 report
+
+Status: available
+Desde: 0.1.0
+
+Lista e exporta relatórios gerados.
+
+Detalhes:
+- Lista arquivos em reports/.
+- Pode exportar relatórios em tar.gz pelo menu.
+- Também aceita autom8 report export para exportar logs e relatórios.
+
+Exemplos:
+  autom8 report
+  autom8 report export

--- a/suite/docs/help/security.txt
+++ b/suite/docs/help/security.txt
@@ -1,0 +1,14 @@
+AutoM8 help: autom8 security
+
+Status: available
+Desde: 0.1.0
+
+Executa checagem básica de segurança local.
+
+Detalhes:
+- Mostra status de firewall conhecido.
+- Lista portas em escuta.
+- Verifica status básico de SSH.
+
+Exemplos:
+  autom8 security

--- a/suite/docs/help/self-update.txt
+++ b/suite/docs/help/self-update.txt
@@ -1,0 +1,13 @@
+AutoM8 help: autom8 self-update
+
+Status: partial
+Desde: 0.1.0
+
+Valida o pacote estável mais recente publicado no GitHub Releases.
+
+Detalhes:
+- Na versão atual, baixa e valida o tar.gz estável quando o usuário confirma.
+- Atualização automática com rollback será implementada em versão futura.
+
+Exemplos:
+  autom8 self-update

--- a/suite/docs/help/update.txt
+++ b/suite/docs/help/update.txt
@@ -1,0 +1,15 @@
+AutoM8 help: autom8 update
+
+Status: available
+Desde: 0.1.0
+
+Atualiza repositórios e pacotes do sistema com confirmação.
+
+Detalhes:
+- Suporta apt, dnf, zypper e pacman.
+- Bloqueia execução em distros não suportadas oficialmente.
+- Exige sudo e registra a execução em logs.
+
+Exemplos:
+  autom8 update
+  autom8 update --dry-run

--- a/suite/docs/help/upgrade-distro.txt
+++ b/suite/docs/help/upgrade-distro.txt
@@ -1,0 +1,12 @@
+AutoM8 help: autom8 upgrade-distro
+
+Status: planned
+Desde: future
+
+Preparação futura para upgrade de versão da distro.
+
+Detalhes:
+- Na versão 0.1.0, o módulo apenas informa que será implementado em versão futura.
+
+Exemplos:
+  autom8 upgrade-distro

--- a/suite/docs/help/users.txt
+++ b/suite/docs/help/users.txt
@@ -1,0 +1,14 @@
+AutoM8 help: autom8 users
+
+Status: available
+Desde: 0.1.0
+
+Lista usuários locais e grupos administrativos.
+
+Detalhes:
+- Mostra usuários com login permitido.
+- Mostra grupos sudo, wheel e admin quando existem.
+- Ações de bloqueio, shell e sudo ficam para versão futura.
+
+Exemplos:
+  autom8 users

--- a/suite/docs/help/version.txt
+++ b/suite/docs/help/version.txt
@@ -1,0 +1,12 @@
+AutoM8 help: autom8 --version
+
+Status: available
+Desde: 0.1.0
+
+Mostra a versão instalada.
+
+Detalhes:
+- Lê a versão instalada a partir do arquivo VERSION dentro da suíte.
+
+Exemplos:
+  autom8 --version

--- a/suite/modules/self_update.sh
+++ b/suite/modules/self_update.sh
@@ -2,7 +2,33 @@
 
 autom8_module_self_update() {
   autom8_title "AutoM8 self-update"
-  autom8_warn_ui "Self-update será implementado após publicação do pacote estável no site."
-  autom8_note "URL futura: https://autom8.oslabs.com.br/downloads/autom8-latest.tar.gz"
-  autom8_summary_warn "Self-update ainda não implementado"
+
+  local repo="${AUTOM8_GITHUB_REPO:-mdmjunior/autom8}"
+  local package_url="${AUTOM8_PACKAGE_URL:-https://github.com/${repo}/releases/latest/download/autom8-latest.tar.gz}"
+  local tmp_dir
+  tmp_dir="$(mktemp -d)"
+
+  autom8_warn_ui "Self-update ainda está em modo inicial."
+  autom8_note "Origem estável configurada:"
+  autom8_note "$package_url"
+  autom8_note "A atualização automática com rollback será implementada em versão futura."
+
+  if autom8_confirm "Deseja baixar o pacote estável mais recente para validação?"; then
+    if curl -fsSL "$package_url" -o "$tmp_dir/autom8-latest.tar.gz"; then
+      autom8_success "Pacote baixado para validação: $tmp_dir/autom8-latest.tar.gz"
+      tar -tzf "$tmp_dir/autom8-latest.tar.gz" >/dev/null
+      autom8_success "Arquivo tar.gz validado."
+      autom8_summary_ok "Pacote estável validado"
+    else
+      autom8_error_ui "Não foi possível baixar o pacote estável."
+      autom8_summary_fail "Falha ao baixar pacote estável"
+      rm -rf "$tmp_dir"
+      return 1
+    fi
+  else
+    autom8_warn_ui "Validação de pacote cancelada."
+    autom8_summary_warn "Self-update cancelado"
+  fi
+
+  rm -rf "$tmp_dir"
 }


### PR DESCRIPTION
## Resumo

Este PR centraliza a documentação do AutoM8 e finaliza a arquitetura de distribuição estável por GitHub Releases.

## Principais mudanças

- Cria fonte única de documentação em `docs/source/autom8-docs.json`.
- Gera dados do site, README, docs auxiliares e help da CLI a partir da fonte única.
- Atualiza `/docs` para documentação profissional com instalação, comandos, módulos, variáveis, release e troubleshooting.
- Atualiza `/modules` para exibir status dos módulos.
- Adiciona `autom8 help` e `autom8 help <comando>`.
- Mantém pacotes fora do site e da VPS.
- Mantém `install.sh` apontando para GitHub Releases latest.
- Documenta variáveis de instalação, empacotamento, release e deploy.

## Validações locais

- `bash -n` nos scripts principais.
- `./scripts/sync-docs.sh`
- `./scripts/build-site.sh`
- Help local com `AUTOM8_ROOT="$PWD/suite" ./suite/bin/autom8 --help`.
- Empacotamento temporário com `AUTOM8_PACKAGE_OUTPUT_DIR`.

## Pós-merge

Após merge na `main`, publicar a release estável:

    ./scripts/release-stable.sh

Depois atualizar a VPS:

    cd /opt/oslabs/repos/autom8
    AUTOM8_SERVICE_NAME=NOME_REAL_DO_SERVICO ./scripts/deploy-site-vps.sh

## Observação

Pacotes da suíte não devem ser publicados pela VPS nem mantidos em `site/public/downloads`.
A fonte oficial do pacote estável passa a ser GitHub Releases.
