### PR TITLE
Corrige validação do script de release estável

### DIFF
--- a/scripts/release-stable.sh
+++ b/scripts/release-stable.sh
@@ -88,8 +88,16 @@ else
     --notes "Release estável do AutoM8 ${VERSION}."
 fi
 
+log "Validando release publicada..."
+gh release view "$TAG" \
+  --repo "$REPO" \
+  --json tagName,name,url,isDraft,isPrerelease,publishedAt
+
 log "Validando assets publicados..."
-gh release view "$TAG" --repo "$REPO" --json tagName,name,isLatest,url
+gh release view "$TAG" \
+  --repo "$REPO" \
+  --json assets \
+  --jq '.assets[].name'
 
 log "Release estável publicada."
 log "URL estável usada pelo install.sh:"


### PR DESCRIPTION
## Resumo

Corrige a validação final do script `scripts/release-stable.sh`.

## Motivo

A versão atual do GitHub CLI disponível no ambiente não aceita o campo JSON `isLatest`.

## Alteração

- Remove o campo `isLatest` da validação.
- Usa apenas campos disponíveis: `tagName`, `name`, `url`, `isDraft`, `isPrerelease` e `publishedAt`.
- Adiciona validação separada dos assets publicados.

## Validação

- `bash -n scripts/release-stable.sh`
- `./scripts/release-stable.sh`
- Verificação dos assets:

    gh release view v0.1.0 --repo mdmjunior/autom8 --json assets --jq '.assets[].name'
