### PR TITLE
Permite build do site via Docker quando npm não existe no host

### DIFF
--- a/scripts/build-site.sh
+++ b/scripts/build-site.sh
@@ -2,6 +2,20 @@
 set -euo pipefail
 
 PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SITE_DIR="$PROJECT_ROOT/site"
+NODE_IMAGE="${AUTOM8_NODE_IMAGE:-node:22-alpine}"
+
+log() {
+  printf '\033[1;34m[AutoM8 Site Build]\033[0m %s\n' "$1"
+}
+
+warn() {
+  printf '\033[1;33m[AutoM8 Site Build]\033[0m %s\n' "$1"
+}
+
+error() {
+  printf '\033[1;31m[AutoM8 Site Build]\033[0m %s\n' "$1" >&2
+}
 
 cd "$PROJECT_ROOT"
 
@@ -10,11 +24,42 @@ cd "$PROJECT_ROOT"
 cp installer/install.sh site/public/install.sh
 chmod +x site/public/install.sh
 
-cd "$PROJECT_ROOT/site"
+if [[ ! -d "$SITE_DIR" ]]; then
+  error "Diretório do site não encontrado: $SITE_DIR"
+  exit 1
+fi
 
-npm install
-npm run build
+run_build_with_local_npm() {
+  log "npm encontrado no host. Gerando build local."
+  cd "$SITE_DIR"
+  npm install
+  npm run build
+}
 
-echo "Site build concluído."
-echo "Observação: pacotes da suíte não são gerados no build do site."
-echo "Pacotes estáveis são publicados somente via GitHub Releases."
+run_build_with_docker_node() {
+  if ! command -v docker >/dev/null 2>&1; then
+    error "npm não foi encontrado e Docker também não está disponível."
+    error "Instale npm no host ou execute em ambiente com Docker."
+    exit 1
+  fi
+
+  log "npm não encontrado no host. Usando Docker com $NODE_IMAGE."
+
+  docker run --rm \
+    --user "$(id -u):$(id -g)" \
+    -e npm_config_cache=/tmp/.npm \
+    -v "$SITE_DIR:/app" \
+    -w /app \
+    "$NODE_IMAGE" \
+    sh -lc 'npm install && npm run build'
+}
+
+if command -v npm >/dev/null 2>&1; then
+  run_build_with_local_npm
+else
+  run_build_with_docker_node
+fi
+
+log "Site build concluído."
+log "Observação: pacotes da suíte não são gerados no build do site."
+log "Pacotes estáveis são publicados somente via GitHub Releases."


### PR DESCRIPTION
## Resumo

Corrige o build do site na VPS quando `npm` não está instalado no host.

## Problema

O deploy falhou na VPS com:

    ./scripts/build-site.sh: line 15: npm: command not found

## Solução

- Mantém uso de `npm` local quando disponível.
- Quando `npm` não existe, usa Docker com imagem `node:22-alpine`.
- Evita exigir Node/npm instalado diretamente na VPS.
- Mantém o fluxo compatível com ambiente local e remoto.

## Validação

- `bash -n scripts/build-site.sh`
- `./scripts/build-site.sh`
- Deploy na VPS com Docker disponível.
