### PR TITLE
Consolida deploy do site AutoM8 no Swarm

### DIFF
--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -1,0 +1,69 @@
+# Deploy do site AutoM8
+
+Este documento descreve o deploy real do site do AutoM8 na VPS compartilhada da OSLabs.
+
+## Regra principal
+
+O site é publicado como uma stack Docker Swarm chamada `autom8`.
+
+O serviço principal é:
+
+    autom8_autom8_site
+
+A imagem local usada pela stack é:
+
+    autom8-site:latest
+
+## O que o deploy faz
+
+O deploy oficial:
+
+- atualiza o repositório na VPS;
+- sincroniza a documentação;
+- copia `installer/install.sh` para o contexto público do site durante o build;
+- remove resíduos de `site/public/downloads`;
+- remove resíduos de `site/dist`;
+- constrói a imagem local `autom8-site:latest`;
+- publica a stack com `docker stack deploy`;
+- valida o serviço e o domínio.
+
+## O que o deploy não faz
+
+O deploy não deve:
+
+- gerar pacote da suíte para a VPS;
+- publicar `autom8-latest.tar.gz` no site;
+- alterar redes Docker;
+- alterar labels do Traefik;
+- usar `docker service update --force` isolado;
+- depender de `npm` instalado no host.
+
+## Pacotes da suíte
+
+Pacotes estáveis da suíte são publicados somente no GitHub Releases.
+
+O instalador público baixa:
+
+    https://github.com/mdmjunior/autom8/releases/latest/download/autom8-latest.tar.gz
+
+## Deploy
+
+Na VPS:
+
+    cd /opt/oslabs/repos/autom8
+    ./scripts/deploy-site-vps.sh
+
+## Validação
+
+Após o deploy:
+
+    docker stack services autom8
+    docker service ps autom8_autom8_site --no-trunc
+    curl -I https://autom8.oslabs.com.br
+    curl -I https://autom8.oslabs.com.br/install.sh
+
+## Rede Docker
+
+A rede declarada em `infra/docker-stack.yml` é considerada fonte da verdade.
+
+O script valida se a rede externa existe, mas não cria, renomeia nem substitui redes.

--- a/infra/deploy-site.sh
+++ b/infra/deploy-site.sh
@@ -1,24 +1,114 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-APP_DIR="/opt/autom8/site"
-STACK_FILE="$APP_DIR/infra/docker-stack.yml"
-STACK_NAME="autom8"
+APP_DIR="${AUTOM8_APP_DIR:-/opt/oslabs/repos/autom8}"
+STACK_FILE="${AUTOM8_STACK_FILE:-$APP_DIR/infra/docker-stack.yml}"
+STACK_NAME="${AUTOM8_STACK_NAME:-autom8}"
+IMAGE_NAME="${AUTOM8_SITE_IMAGE:-autom8-site:latest}"
+DOMAIN="${AUTOM8_DOMAIN:-https://autom8.oslabs.com.br}"
+SERVICE_NAME="${AUTOM8_SERVICE_NAME:-autom8_autom8_site}"
+
+log() {
+  printf '\033[1;34m[AutoM8 Infra Deploy]\033[0m %s\n' "$1"
+}
+
+warn() {
+  printf '\033[1;33m[AutoM8 Infra Deploy]\033[0m %s\n' "$1"
+}
+
+error() {
+  printf '\033[1;31m[AutoM8 Infra Deploy]\033[0m %s\n' "$1" >&2
+}
+
+if [[ ! -d "$APP_DIR/.git" ]]; then
+  error "Diretório do projeto não encontrado ou não é repo Git: $APP_DIR"
+  exit 1
+fi
+
+if [[ ! -f "$STACK_FILE" ]]; then
+  error "Stack file não encontrado: $STACK_FILE"
+  exit 1
+fi
 
 cd "$APP_DIR"
 
-echo "Gerando pacote da suíte..."
-./scripts/package.sh
+cleanup_generated_files() {
+  if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    if [[ -n "$(git status --porcelain -- site/public/install.sh 2>/dev/null)" ]]; then
+      warn "Restaurando site/public/install.sh para não deixar o repo sujo."
+      git restore site/public/install.sh || true
+    fi
+  fi
+}
 
-echo "Sincronizando install.sh público..."
+trap cleanup_generated_files EXIT
+
+log "Projeto: $APP_DIR"
+log "Stack: $STACK_NAME"
+log "Stack file: $STACK_FILE"
+log "Imagem: $IMAGE_NAME"
+log "Serviço: $SERVICE_NAME"
+
+log "Validando rede externa declarada na stack sem alterá-la."
+
+STACK_NETWORKS="$(
+  awk '
+    /^networks:/ { in_networks=1; next }
+    in_networks && /^[^[:space:]]/ { in_networks=0 }
+    in_networks && /^  [A-Za-z0-9_.-]+:/ {
+      gsub(":", "", $1)
+      print $1
+    }
+  ' "$STACK_FILE" | sort -u
+)"
+
+for network_name in $STACK_NETWORKS; do
+  if grep -A4 -E "^  ${network_name}:" "$STACK_FILE" | grep -q "external: true"; then
+    if ! docker network inspect "$network_name" >/dev/null 2>&1; then
+      error "Rede externa declarada não existe no Docker: $network_name"
+      error "Não vou criar, renomear ou trocar rede automaticamente."
+      exit 1
+    fi
+    log "Rede externa OK: $network_name"
+  fi
+done
+
+log "Removendo resíduos locais de pacote/site."
+rm -rf "$APP_DIR/site/public/downloads"
+rm -rf "$APP_DIR/site/dist"
+
+log "Sincronizando documentação."
+./scripts/sync-docs.sh
+
+log "Sincronizando install.sh público para o contexto do build."
 cp installer/install.sh site/public/install.sh
 chmod +x site/public/install.sh
 
-echo "Construindo imagem Docker..."
-docker build -t autom8-site:latest ./site
+log "Construindo imagem Docker local."
+docker build -t "$IMAGE_NAME" ./site
 
-echo "Publicando stack no Docker Swarm..."
-docker stack deploy -c "$STACK_FILE" "$STACK_NAME"
+log "Validando imagem local."
+docker image inspect "$IMAGE_NAME" >/dev/null
 
-echo "Status:"
+log "Publicando stack no Docker Swarm."
+docker stack deploy -c "$STACK_FILE" "$STACK_NAME" --detach=false
+
+log "Aguardando serviço estabilizar."
+sleep 5
+
 docker stack services "$STACK_NAME"
+docker service ps "$SERVICE_NAME" --no-trunc | head -20
+
+REPLICAS="$(docker service ls --filter "name=$SERVICE_NAME" --format '{{.Replicas}}' | head -1)"
+
+if [[ "$REPLICAS" != "1/1" ]]; then
+  error "Serviço não ficou saudável. Réplicas atuais: ${REPLICAS:-indisponível}"
+  docker service ps "$SERVICE_NAME" --no-trunc | head -30
+  exit 1
+fi
+
+log "Validando domínio."
+curl -I "$DOMAIN" || true
+curl -I "$DOMAIN/install.sh" || true
+
+log "Deploy finalizado com sucesso."

--- a/infra/docker-stack.yml
+++ b/infra/docker-stack.yml
@@ -2,14 +2,14 @@ services:
   autom8_site:
     image: autom8-site:latest
     networks:
-      - groomix-public
+      - oslabs-public
     deploy:
       replicas: 1
       restart_policy:
         condition: any
       labels:
         - "traefik.enable=true"
-        - "traefik.docker.network=groomix-public"
+        - "traefik.swarm.network=oslabs-public"
         - "traefik.http.routers.autom8.rule=Host(`autom8.oslabs.com.br`)"
         - "traefik.http.routers.autom8.entrypoints=websecure"
         - "traefik.http.routers.autom8.tls=true"
@@ -18,5 +18,5 @@ services:
         - "traefik.http.services.autom8.loadbalancer.server.port=80"
 
 networks:
-  groomix-public:
+  oslabs-public:
     external: true

--- a/scripts/deploy-site-vps.sh
+++ b/scripts/deploy-site-vps.sh
@@ -3,16 +3,9 @@ set -euo pipefail
 
 REPO_DIR="${AUTOM8_REPO_DIR:-/opt/oslabs/repos/autom8}"
 BRANCH="${AUTOM8_BRANCH:-main}"
-DOMAIN="${AUTOM8_DOMAIN:-https://autom8.oslabs.com.br}"
-SERVICE_NAME="${AUTOM8_SERVICE_NAME:-}"
-RESTART_SERVICE="${AUTOM8_RESTART_SERVICE:-1}"
 
 log() {
   printf '\033[1;34m[AutoM8 Deploy]\033[0m %s\n' "$1"
-}
-
-warn() {
-  printf '\033[1;33m[AutoM8 Deploy]\033[0m %s\n' "$1"
 }
 
 error() {
@@ -21,7 +14,6 @@ error() {
 
 log "Repo: $REPO_DIR"
 log "Branch: $BRANCH"
-log "Domínio: $DOMAIN"
 
 if [[ ! -d "$REPO_DIR/.git" ]]; then
   error "Diretório informado não parece ser um repositório Git: $REPO_DIR"
@@ -30,8 +22,7 @@ fi
 
 cd "$REPO_DIR"
 
-CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
-log "Branch atual no servidor: $CURRENT_BRANCH"
+log "Branch atual no servidor: $(git rev-parse --abbrev-ref HEAD)"
 
 if [[ -n "$(git status --porcelain)" ]]; then
   error "O repositório remoto possui alterações locais não commitadas."
@@ -40,56 +31,13 @@ if [[ -n "$(git status --porcelain)" ]]; then
   exit 1
 fi
 
-log "Atualizando código..."
+log "Atualizando código."
 git fetch origin "$BRANCH"
 git checkout "$BRANCH"
 git pull --ff-only origin "$BRANCH"
 
-log "Garantindo permissão dos scripts..."
-chmod +x scripts/build-site.sh
-chmod +x scripts/deploy-site-vps.sh
+log "Garantindo permissão dos scripts."
+chmod +x infra/deploy-site.sh
 
-log "Gerando build do site..."
-./scripts/build-site.sh
-
-log "Validando artefatos do site..."
-
-if [[ ! -d "$REPO_DIR/site/dist" ]]; then
-  error "Build não gerou site/dist"
-  exit 1
-fi
-
-if [[ ! -f "$REPO_DIR/site/dist/install.sh" ]]; then
-  error "Build não gerou site/dist/install.sh"
-  exit 1
-fi
-
-if [[ -d "$REPO_DIR/site/dist/downloads" ]]; then
-  warn "Diretório site/dist/downloads encontrado."
-  warn "Pacotes da suíte não devem mais ser publicados pela VPS."
-  warn "Revise se há arquivos legados no site/public/downloads."
-fi
-
-log "Artefatos do site validados:"
-ls -lah "$REPO_DIR/site/dist" | head
-
-if [[ "$RESTART_SERVICE" == "1" ]]; then
-  if [[ -n "$SERVICE_NAME" ]]; then
-    log "Reiniciando serviço Docker Swarm informado: $SERVICE_NAME"
-    docker service update --force "$SERVICE_NAME"
-    docker service ps "$SERVICE_NAME" --no-trunc | head -20
-  else
-    warn "AUTOM8_SERVICE_NAME não foi informado."
-    warn "Build concluído, mas nenhum serviço foi reiniciado."
-    warn "Para reiniciar no deploy, use:"
-    warn "AUTOM8_SERVICE_NAME=nome_do_servico ./scripts/deploy-site-vps.sh"
-  fi
-else
-  warn "Reinício de serviço desativado por AUTOM8_RESTART_SERVICE=0."
-fi
-
-log "Testando domínio..."
-curl -I "$DOMAIN" || true
-curl -I "$DOMAIN/install.sh" || true
-
-log "Deploy finalizado."
+log "Delegando deploy para infra/deploy-site.sh."
+exec ./infra/deploy-site.sh


### PR DESCRIPTION
## Resumo

Consolida o fluxo oficial de deploy do site AutoM8 no Docker Swarm.

## Problema

Havia dois fluxos concorrentes:

- `scripts/deploy-site-vps.sh`
- `infra/deploy-site.sh`

O fluxo em `scripts/` tentava atualizar o serviço sem reconstruir a imagem local `autom8-site:latest`, o que podia deixar o serviço parado com erro de imagem ausente.

## Solução

- `scripts/deploy-site-vps.sh` passa a apenas atualizar o repo e delegar para `infra/deploy-site.sh`.
- `infra/deploy-site.sh` vira o deploy real da stack.
- O deploy constrói `autom8-site:latest` antes de publicar a stack.
- O deploy remove resíduos de `site/public/downloads` e `site/dist`.
- O deploy não gera pacote local da suíte.
- O deploy não altera rede Docker nem labels do Traefik.
- A rede declarada no `infra/docker-stack.yml` é preservada como fonte da verdade.

## Validação

- `bash -n infra/deploy-site.sh`
- `bash -n scripts/deploy-site-vps.sh`
- Deploy na VPS com `./scripts/deploy-site-vps.sh`
- `docker stack services autom8`
- `curl -I https://autom8.oslabs.com.br`
- `curl -I https://autom8.oslabs.com.br/install.sh`
