### PR TITLE
docs: consolidate repository and website documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,24 @@
+# Contribuindo com o AutoM8
+
+O desenvolvimento contínuo acontece em `develop`. A branch `main` representa
+o estado promovido e deve receber mudanças somente por pull request.
+
+## Fluxo
+
+```bash
+git checkout develop
+git pull --ff-only origin develop
+./scripts/sync-docs.sh
+./scripts/check.sh all
+```
+
+Depois da validação, faça commit e push para `develop`. A promoção para
+`main` deve ocorrer com o Quality Gate aprovado.
+
+## Regras
+
+- Preserve a compatibilidade da CLI e a versão estável, salvo mudança planejada.
+- Atualize `docs/source/autom8-docs.json` quando comandos ou status mudarem.
+- Execute `./scripts/sync-docs.sh` antes de versionar documentação.
+- Não edite apenas arquivos gerados.
+- Não inclua credenciais, logs sensíveis ou artefatos de runtime.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,15 @@
-# AutoM8 - Linux Management Suite
+# AutoM8
 
-AutoM8 é uma suíte local para preparar, diagnosticar, atualizar e manter ambientes Linux com visual terminal premium, catálogo de apps, logs e controle explícito do usuário.
+AutoM8 é uma CLI local para instalar aplicativos, aplicar perfis e executar manutenção Linux com confirmação, logs e modo de simulação.
 
-**OSLabs**
+[Site oficial](https://autom8.oslabs.com.br) · [Documentação](https://autom8.oslabs.com.br/docs) · [Releases](https://github.com/mdmjunior/autom8/releases)
 
-## Site
+## Estado atual
 
-https://autom8.oslabs.com.br
+- Versão estável: `0.2.0`
+- Catálogo: **76 apps**, **10 categorias** e **6 perfis**
+- Validado em Ubuntu Desktop e Fedora Workstation.
+- Compatível com fluxos baseados em `apt`, `dnf`, `zypper` e `pacman`.
 
 ## Instalação
 
@@ -16,87 +19,71 @@ Execute com um usuário comum que tenha permissão de `sudo`:
 curl -fsSL https://autom8.oslabs.com.br/install.sh | bash
 ```
 
-Depois da instalação:
+Primeiro uso:
 
 ```bash
 export PATH="/opt/autom8/bin:$PATH"
 autom8
 autom8 doctor
+autom8 apps search docker
+autom8 profiles list
 ```
 
-## Distribuição estável
+## Comandos essenciais
 
-O instalador baixa a última versão estável publicada em GitHub Releases:
+| Comando | Descrição |
+| --- | --- |
+| `autom8 apps` | Instala e remove aplicativos por catálogo local atualizável online. |
+| `autom8 profiles` | Lista, detalha, instala e remove perfis baseados no catálogo de apps. |
+| `autom8 update` | Atualiza repositórios e pacotes do sistema com confirmação. |
+| `autom8 clean` | Executa limpeza segura com confirmação explícita. |
+| `autom8 doctor` | Valida instalação, dependências, PATH, release e versão online. |
+| `autom8 diagnose` | Gera diagnóstico completo local ou privado sanitizado. |
+| `autom8 security` | Executa checagem básica de segurança local. |
+| `autom8 report` | Lista e exporta relatórios gerados. |
 
-```text
-https://github.com/mdmjunior/autom8/releases/latest/download/autom8-latest.tar.gz
-```
+Use `autom8 help` para a lista completa e `autom8 help <comando>` para detalhes.
 
-A VPS não hospeda pacotes da suíte. O site publica o instalador e a documentação.
+### Em evolução
 
-## Comandos principais
-
-```bash
-autom8 apps
-autom8 backup
-autom8 clean
-autom8 config
-autom8 diagnose
-autom8 docker
-autom8 doctor
-autom8
-autom8 profiles
-autom8 report
-autom8 security
-autom8 self-update
-autom8 update
-autom8 upgrade-distro
-autom8 users
-autom8 --version
-```
-
-## Status dos módulos
-
-| Módulo | Comando | Status | Versão |
-| --- | --- | --- | --- |
-| Apps | `autom8 apps` | available | 0.2.0 |
-| Perfis | `autom8 profiles` | available | 0.2.0 |
-| Atualização do Sistema | `autom8 update` | available | 0.1.1 |
-| Limpeza | `autom8 clean` | available | 0.1.1 |
-| Configurações | `autom8 config` | available | 0.1.1 |
-| Diagnóstico | `autom8 diagnose` | available | 0.1.1 |
-| Doctor | `autom8 doctor` | available | 0.1.1 |
-| Segurança | `autom8 security` | available | 0.1.1 |
-| Docker | `autom8 docker` | available | 0.1.1 |
-| Usuários | `autom8 users` | available | 0.1.1 |
-| Relatórios | `autom8 report` | available | 0.1.1 |
-| Self-update | `autom8 self-update` | partial | 0.1.0 |
-| Backup | `autom8 backup` | planned | 0.3.0 |
-| Upgrade da distribuição | `autom8 upgrade-distro` | planned | futura |
-
-## Documentação
-
-- Site: `https://autom8.oslabs.com.br/docs`
-- Fonte única: `docs/source/autom8-docs.json`
-- Help da CLI: `suite/docs/help.txt` e `suite/docs/help/`
+- **Parcial:** `autom8 self-update` — Valida o pacote estável mais recente publicado no GitHub Releases.
+- **Planejado:** `autom8 backup` — Backups simples antes de operações sensíveis.
+- **Planejado:** `autom8 upgrade-distro` — Preparação futura para upgrade de versão da distro.
 
 ## Desenvolvimento
 
 ```bash
+./scripts/bootstrap-dev.sh
 ./scripts/sync-docs.sh
-./scripts/build-site.sh
+./scripts/check.sh all
+./scripts/website/build.sh
 ```
 
-## Release estável
+Fluxo do projeto: mudanças entram em `develop`; a promoção para `main` ocorre por pull request com Quality Gate.
 
-Após merge na `main`:
+## Estrutura
 
-```bash
-./scripts/release-stable.sh
+```text
+suite/      CLI instalada em /opt/autom8
+installer/  instalador público
+site/       website Astro
+docs/       fonte e documentos técnicos
+scripts/    validação, build, pacote e release
 ```
 
-## Créditos
+## Documentação do repositório
 
-OSLabs.
+- [Índice técnico](docs/README.md)
+- [Arquitetura](docs/ARCHITECTURE.md)
+- [Releases](docs/RELEASES.md)
+- [Variáveis](docs/VARIABLES.md)
+- [Como contribuir](CONTRIBUTING.md)
+- [Segurança](SECURITY.md)
 
-Um produto OSLabs para a comunidade Linux.
+A fonte canônica é `docs/source/autom8-docs.json`. Arquivos gerados não devem ser editados isoladamente.
+
+## Licença
+
+[GNU GPL-3.0](LICENSE).
+
+AutoM8 é um produto OSLabs para a comunidade Linux.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,17 @@
+# Segurança
+
+Relate vulnerabilidades pela opção **Security → Report a vulnerability** do
+repositório. Não publique detalhes de exploração, credenciais ou dados reais
+em issues abertas.
+
+Inclua, quando possível:
+
+- versão do AutoM8;
+- distribuição e versão do Linux;
+- módulo ou comando afetado;
+- impacto observado;
+- passos mínimos para reprodução;
+- logs sanitizados.
+
+A versão estável mais recente recebe prioridade. Correções seguem por
+`develop`, passam pelo Quality Gate e são promovidas para `main`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,27 +1,30 @@
 # Documentação do AutoM8
 
-A documentação oficial é gerada a partir de uma fonte única:
+Este diretório reúne a documentação técnica e operacional do projeto.
 
-```text
-docs/source/autom8-docs.json
-```
+## Para usuários
 
-Esse arquivo alimenta:
+- [Guia rápido](https://autom8.oslabs.com.br/docs)
+- [README do projeto](../README.md)
+- Ajuda local: `autom8 help` e `autom8 help <comando>`
 
-- README.md
-- site/src/data/docs.json
-- site/src/data/modules.json
-- site/src/data/profiles.json
-- site/src/data/catalog-summary.json
-- site/src/data/terminal-sessions.json
-- site/src/data/roadmap.json
-- site/src/data/changelog.json
-- site/src/data/documentation.json
-- suite/docs/help.txt
-- suite/docs/help/<comando>.txt
+## Para manutenção
 
-Para sincronizar:
+- [Arquitetura](ARCHITECTURE.md)
+- [Releases](RELEASES.md)
+- [Variáveis](VARIABLES.md)
+- [Contribuição](../CONTRIBUTING.md)
+- [Segurança](../SECURITY.md)
+
+## Fonte única
+
+`docs/source/autom8-docs.json` alimenta o README, os dados do site e a ajuda da CLI.
+
+Para sincronizar e validar:
 
 ```bash
 ./scripts/sync-docs.sh
+./scripts/check.sh all
 ```
+
+Não edite arquivos gerados sem atualizar a fonte ou o gerador.

--- a/docs/source/autom8-docs.json
+++ b/docs/source/autom8-docs.json
@@ -7,8 +7,8 @@
     "githubRepo": "mdmjunior/autom8",
     "currentVersion": "0.2.0",
     "currentDate": "2026-07-10",
-    "summary": "AutoM8 é uma suíte local para preparar, diagnosticar, atualizar e manter ambientes Linux com visual terminal premium, catálogo de apps, logs e controle explícito do usuário.",
-    "positioning": "Automação Linux local, segura, auditável e amigável para usuários iniciantes, técnicos e administradores."
+    "summary": "AutoM8 é uma CLI local para instalar aplicativos, aplicar perfis e executar manutenção Linux com confirmação, logs e modo de simulação.",
+    "positioning": "Automação Linux local, auditável e previsível para desktops e servidores."
   },
   "releasePolicy": {
     "stableSource": "GitHub Releases",

--- a/scripts/sync-docs.sh
+++ b/scripts/sync-docs.sh
@@ -327,16 +327,57 @@ for c in commands:
 
     write_text(f"suite/docs/help/{c['slug']}.txt", "\n".join(lines))
 
+
+# DOCS:README:START
+status_labels = {
+    "available": "Disponível",
+    "partial": "Parcial",
+    "planned": "Planejado"
+}
+
+essential_slugs = [
+    "apps",
+    "profiles",
+    "update",
+    "clean",
+    "doctor",
+    "diagnose",
+    "security",
+    "report"
+]
+
+commands_by_slug = {
+    command["slug"]: command
+    for command in commands
+}
+
+essential_commands = [
+    commands_by_slug[slug]
+    for slug in essential_slugs
+    if slug in commands_by_slug
+]
+
 readme = [
-    f"# {product['fullName']}",
+    f"# {product['name']}",
     "",
     product["summary"],
     "",
-    f"**{product['brand']}**",
+    (
+        f"[Site oficial]({product['siteUrl']}) · "
+        f"[Documentação]({product['siteUrl']}/docs) · "
+        f"[Releases](https://github.com/{product['githubRepo']}/releases)"
+    ),
     "",
-    "## Site",
+    "## Estado atual",
     "",
-    product["siteUrl"],
+    f"- Versão estável: `{product['currentVersion']}`",
+    (
+        f"- Catálogo: **{len(apps_catalog['apps'])} apps**, "
+        f"**{len(apps_catalog['categories'])} categorias** e "
+        f"**{len(profiles)} perfis**"
+    ),
+    "- Validado em Ubuntu Desktop e Fedora Workstation.",
+    "- Compatível com fluxos baseados em `apt`, `dnf`, `zypper` e `pacman`.",
     "",
     "## Instalação",
     "",
@@ -346,105 +387,124 @@ readme = [
     install["command"],
     "```",
     "",
-    "Depois da instalação:",
+    "Primeiro uso:",
     "",
     "```bash",
     *install["after"],
+    "autom8 apps search docker",
+    "autom8 profiles list",
     "```",
     "",
-    "## Distribuição estável",
+    "## Comandos essenciais",
     "",
-    f"O instalador baixa a última versão estável publicada em GitHub Releases:",
-    "",
-    "```text",
-    release_policy["latestPackageUrl"],
-    "```",
-    "",
-    "A VPS não hospeda pacotes da suíte. O site publica o instalador e a documentação.",
-    "",
-    "## Comandos principais",
-    "",
-    "```bash",
+    "| Comando | Descrição |",
+    "| --- | --- |"
 ]
 
-for c in commands:
-    readme.append(c["command"])
+for command in essential_commands:
+    readme.append(
+        f"| `{command['command']}` | {command['summary']} |"
+    )
 
 readme.extend([
-    "```",
     "",
-    "## Status dos módulos",
+    "Use `autom8 help` para a lista completa e "
+    "`autom8 help <comando>` para detalhes.",
     "",
-    "| Módulo | Comando | Status | Versão |",
-    "| --- | --- | --- | --- |"
+    "### Em evolução",
+    ""
 ])
 
-for m in modules:
-    readme.append(f"| {m['name']} | `{m['command']}` | {m['status']} | {m['version']} |")
+for command in partial + planned:
+    readme.append(
+        f"- **{status_labels[command['status']]}:** "
+        f"`{command['command']}` — {command['summary']}"
+    )
 
 readme.extend([
-    "",
-    "## Documentação",
-    "",
-    "- Site: `https://autom8.oslabs.com.br/docs`",
-    "- Fonte única: `docs/source/autom8-docs.json`",
-    "- Help da CLI: `suite/docs/help.txt` e `suite/docs/help/`",
     "",
     "## Desenvolvimento",
     "",
     "```bash",
+    "./scripts/bootstrap-dev.sh",
     "./scripts/sync-docs.sh",
-    "./scripts/build-site.sh",
+    "./scripts/check.sh all",
+    "./scripts/website/build.sh",
     "```",
     "",
-    "## Release estável",
+    "Fluxo do projeto: mudanças entram em `develop`; "
+    "a promoção para `main` ocorre por pull request com Quality Gate.",
     "",
-    "Após merge na `main`:",
+    "## Estrutura",
     "",
-    "```bash",
-    "./scripts/release-stable.sh",
+    "```text",
+    "suite/      CLI instalada em /opt/autom8",
+    "installer/  instalador público",
+    "site/       website Astro",
+    "docs/       fonte e documentos técnicos",
+    "scripts/    validação, build, pacote e release",
     "```",
     "",
-    "## Créditos",
+    "## Documentação do repositório",
     "",
-    f"{product['brand']}.",
+    "- [Índice técnico](docs/README.md)",
+    "- [Arquitetura](docs/ARCHITECTURE.md)",
+    "- [Releases](docs/RELEASES.md)",
+    "- [Variáveis](docs/VARIABLES.md)",
+    "- [Como contribuir](CONTRIBUTING.md)",
+    "- [Segurança](SECURITY.md)",
     "",
-    "Um produto OSLabs para a comunidade Linux."
+    "A fonte canônica é `docs/source/autom8-docs.json`. "
+    "Arquivos gerados não devem ser editados isoladamente.",
+    "",
+    "## Licença",
+    "",
+    "[GNU GPL-3.0](LICENSE).",
+    "",
+    "AutoM8 é um produto OSLabs para a comunidade Linux."
 ])
 
 write_text("README.md", md(readme))
+# DOCS:README:END
 
+
+# DOCS:INDEX:START
 docs_readme = [
     "# Documentação do AutoM8",
     "",
-    "A documentação oficial é gerada a partir de uma fonte única:",
+    "Este diretório reúne a documentação técnica e operacional do projeto.",
     "",
-    "```text",
-    "docs/source/autom8-docs.json",
-    "```",
+    "## Para usuários",
     "",
-    "Esse arquivo alimenta:",
+    f"- [Guia rápido]({product['siteUrl']}/docs)",
+    "- [README do projeto](../README.md)",
+    "- Ajuda local: `autom8 help` e `autom8 help <comando>`",
     "",
-    "- README.md",
-    "- site/src/data/docs.json",
-    "- site/src/data/modules.json",
-    "- site/src/data/profiles.json",
-    "- site/src/data/catalog-summary.json",
-    "- site/src/data/terminal-sessions.json",
-    "- site/src/data/roadmap.json",
-    "- site/src/data/changelog.json",
-    "- site/src/data/documentation.json",
-    "- suite/docs/help.txt",
-    "- suite/docs/help/<comando>.txt",
+    "## Para manutenção",
     "",
-    "Para sincronizar:",
+    "- [Arquitetura](ARCHITECTURE.md)",
+    "- [Releases](RELEASES.md)",
+    "- [Variáveis](VARIABLES.md)",
+    "- [Contribuição](../CONTRIBUTING.md)",
+    "- [Segurança](../SECURITY.md)",
+    "",
+    "## Fonte única",
+    "",
+    "`docs/source/autom8-docs.json` alimenta o README, "
+    "os dados do site e a ajuda da CLI.",
+    "",
+    "Para sincronizar e validar:",
     "",
     "```bash",
     "./scripts/sync-docs.sh",
-    "```"
+    "./scripts/check.sh all",
+    "```",
+    "",
+    "Não edite arquivos gerados sem atualizar a fonte ou o gerador."
 ]
 
 write_text("docs/README.md", md(docs_readme))
+# DOCS:INDEX:END
 
 releases_md = [
     "# Releases do AutoM8",

--- a/site/src/data/documentation.json
+++ b/site/src/data/documentation.json
@@ -7,8 +7,8 @@
     "githubRepo": "mdmjunior/autom8",
     "currentVersion": "0.2.0",
     "currentDate": "2026-07-10",
-    "summary": "AutoM8 é uma suíte local para preparar, diagnosticar, atualizar e manter ambientes Linux com visual terminal premium, catálogo de apps, logs e controle explícito do usuário.",
-    "positioning": "Automação Linux local, segura, auditável e amigável para usuários iniciantes, técnicos e administradores."
+    "summary": "AutoM8 é uma CLI local para instalar aplicativos, aplicar perfis e executar manutenção Linux com confirmação, logs e modo de simulação.",
+    "positioning": "Automação Linux local, auditável e previsível para desktops e servidores."
   },
   "releasePolicy": {
     "stableSource": "GitHub Releases",

--- a/site/src/pages/docs.astro
+++ b/site/src/pages/docs.astro
@@ -2,68 +2,88 @@
 import BaseLayout from '../layouts/BaseLayout.astro';
 import documentation from '../data/documentation.json';
 
-const availableCommands = documentation.commands.filter((item) => item.status === 'available');
-const partialCommands = documentation.commands.filter((item) => item.status === 'partial');
-const plannedCommands = documentation.commands.filter((item) => item.status === 'planned');
+const availableCommands = documentation.commands.filter(
+  (item) => item.status === 'available'
+);
 
-const statusLabel = {
+const evolvingCommands = documentation.commands.filter(
+  (item) => item.status !== 'available'
+);
+
+const publicRequirements = documentation.requirements.filter(
+  (item): item is string => typeof item === 'string'
+);
+
+const statusLabel: Record<string, string> = {
   available: 'Disponível',
   partial: 'Parcial',
   planned: 'Planejado'
 };
 
-const statusClass = {
+const statusClass: Record<string, string> = {
   available: 'autom8-status-badge',
   partial: 'autom8-version-badge',
   planned: 'autom8-card-kicker'
 };
+
+const compatibility = [
+  {
+    name: 'Ubuntu Desktop',
+    status: 'Validada',
+    detail: 'Fluxos principais validados com apt.'
+  },
+  {
+    name: 'Fedora Workstation',
+    status: 'Validada',
+    detail: 'Fluxos principais validados com dnf.'
+  },
+  {
+    name: 'Outras distribuições',
+    status: 'Compatibilidade',
+    detail: 'Há suporte por gerenciador para zypper e pacman, com cobertura de testes diferente.'
+  }
+];
+
+const repositoryDocs = [
+  {
+    title: 'README',
+    description: 'Visão geral, instalação e comandos essenciais.',
+    href: 'https://github.com/mdmjunior/autom8#readme'
+  },
+  {
+    title: 'Arquitetura',
+    description: 'Organização da CLI, website, instalador e automações.',
+    href: 'https://github.com/mdmjunior/autom8/blob/main/docs/ARCHITECTURE.md'
+  },
+  {
+    title: 'Contribuição',
+    description: 'Fluxo de desenvolvimento, sincronização e validação.',
+    href: 'https://github.com/mdmjunior/autom8/blob/main/CONTRIBUTING.md'
+  },
+  {
+    title: 'Segurança',
+    description: 'Canal e informações necessárias para relatar vulnerabilidades.',
+    href: 'https://github.com/mdmjunior/autom8/blob/main/SECURITY.md'
+  }
+];
 ---
 
 <BaseLayout
-  title="Docs · AutoM8"
-  description="Documentação oficial do AutoM8: instalação, comandos, módulos, releases, variáveis e solução de problemas."
+  title="Documentação · AutoM8"
+  description="Guia conciso para instalar, validar e usar o AutoM8."
 >
   <section class="site-page-hero">
     <div class="site-page-hero__inner">
       <p class="page-eyebrow">Documentação</p>
-      <h1 class="page-title">Documentação oficial do AutoM8.</h1>
+      <h1 class="page-title">Instale, valide e use.</h1>
       <p class="page-description">
-        Instale, valide, diagnostique e mantenha ambientes Linux com comandos claros, documentação versionada e distribuição estável via GitHub Releases.
+        Guia rápido da versão {documentation.product.currentVersion}.
+        A documentação técnica permanece no repositório.
       </p>
 
       <div class="page-actions">
         <a href="#instalacao" class="autom8-primary-button">Instalar</a>
-        <a href="#comandos" class="autom8-secondary-button">Ver comandos</a>
-      </div>
-    </div>
-  </section>
-
-  <section id="visao-geral" class="site-page-section">
-    <div class="site-page-section__inner">
-      <div class="section-heading">
-        <p class="section-eyebrow text-blue-300">Visão geral</p>
-        <h2>{documentation.product.fullName}</h2>
-        <p>{documentation.product.summary}</p>
-      </div>
-
-      <div class="autom8-content-grid autom8-content-grid--three">
-        <article class="autom8-standard-card">
-          <span class="autom8-card-kicker">local</span>
-          <h3>Execução local</h3>
-          <p>O AutoM8 roda na própria máquina Linux e mantém relatórios, logs e configurações dentro da instalação local.</p>
-        </article>
-
-        <article class="autom8-standard-card">
-          <span class="autom8-card-kicker">controle</span>
-          <h3>Ações revisáveis</h3>
-          <p>Comandos administrativos exigem sudo, usam confirmações quando necessário e registram ações em logs.</p>
-        </article>
-
-        <article class="autom8-standard-card">
-          <span class="autom8-card-kicker">release</span>
-          <h3>Pacote estável</h3>
-          <p>O instalador baixa a última versão estável publicada no GitHub Releases, não pacotes locais ou da VPS.</p>
-        </article>
+        <a href="#comandos" class="autom8-secondary-button">Comandos</a>
       </div>
     </div>
   </section>
@@ -71,40 +91,55 @@ const statusClass = {
   <section id="instalacao" class="site-page-section">
     <div class="site-page-section__inner">
       <div class="section-heading">
-        <p class="section-eyebrow text-green-300">Instalação</p>
-        <h2>Instale com um comando.</h2>
-        <p>Execute com usuário comum que tenha permissão de sudo. Não execute diretamente como root.</p>
+        <p class="section-eyebrow text-green-300">Início rápido</p>
+        <h2>Instalação oficial</h2>
+        <p>
+          Execute como usuário comum com permissão de sudo.
+          O instalador bloqueia execução direta como root.
+        </p>
       </div>
 
       <div class="autom8-command-panel">
         <div class="autom8-command-panel__header">
           <span>terminal</span>
-          <strong>install.sh</strong>
+          <strong>instalar</strong>
         </div>
         <pre><code>{documentation.install.command}</code></pre>
       </div>
 
-      <div class="autom8-content-grid autom8-content-grid--three mt-8">
-        {documentation.install.notes.map((note) => (
-          <article class="autom8-standard-card">
-            <span class="autom8-card-kicker">nota</span>
-            <p>{note}</p>
-          </article>
-        ))}
+      <div class="autom8-command-panel mt-6">
+        <div class="autom8-command-panel__header">
+          <span>terminal</span>
+          <strong>primeiro uso</strong>
+        </div>
+        <pre><code>{documentation.install.after.join('\n')}</code></pre>
       </div>
     </div>
   </section>
 
-  <section id="requisitos" class="site-page-section">
+  <section id="compatibilidade" class="site-page-section">
     <div class="site-page-section__inner">
       <div class="section-heading">
-        <p class="section-eyebrow text-blue-300">Requisitos</p>
-        <h2>Base necessária</h2>
-        <p>O instalador prepara dependências comuns, mas estes pontos ajudam a entender o ambiente esperado.</p>
+        <p class="section-eyebrow text-blue-300">Compatibilidade</p>
+        <h2>Ambientes suportados</h2>
+        <p>
+          O suporte administrativo depende do gerenciador de pacotes
+          reconhecido e da cobertura de testes da distribuição.
+        </p>
       </div>
 
-      <div class="autom8-timeline">
-        {documentation.requirements.map((item) => (
+      <div class="autom8-content-grid autom8-content-grid--three">
+        {compatibility.map((item) => (
+          <article class="autom8-standard-card">
+            <span class="autom8-status-badge">{item.status}</span>
+            <h3>{item.name}</h3>
+            <p>{item.detail}</p>
+          </article>
+        ))}
+      </div>
+
+      <div class="autom8-timeline mt-8">
+        {publicRequirements.map((item) => (
           <article class="autom8-release-card">
             <p>{item}</p>
           </article>
@@ -118,7 +153,10 @@ const statusClass = {
       <div class="section-heading">
         <p class="section-eyebrow text-green-300">CLI</p>
         <h2>Comandos disponíveis</h2>
-        <p>Estes comandos estão disponíveis na versão atual da suíte.</p>
+        <p>
+          Use <code>autom8 help</code> para a lista local e
+          <code> autom8 help &lt;comando&gt;</code> para detalhes.
+        </p>
       </div>
 
       <div class="autom8-table-card">
@@ -126,7 +164,7 @@ const statusClass = {
           <thead>
             <tr>
               <th>Comando</th>
-              <th>Status</th>
+              <th>Desde</th>
               <th>Descrição</th>
             </tr>
           </thead>
@@ -134,7 +172,7 @@ const statusClass = {
             {availableCommands.map((item) => (
               <tr>
                 <td><code>{item.command}</code></td>
-                <td><span class={statusClass[item.status]}>{statusLabel[item.status]}</span></td>
+                <td>{item.since}</td>
                 <td>{item.summary}</td>
               </tr>
             ))}
@@ -143,14 +181,20 @@ const statusClass = {
       </div>
 
       <div class="section-heading mt-12">
-        <h2>Comandos parciais e planejados</h2>
-        <p>Esses comandos já aparecem no menu ou na CLI, mas ainda não representam funcionalidade completa.</p>
+        <p class="section-eyebrow text-blue-300">Em evolução</p>
+        <h2>Parcial e planejado</h2>
+        <p>
+          Estes comandos existem na interface, mas ainda não representam
+          funcionalidade completa.
+        </p>
       </div>
 
       <div class="autom8-content-grid autom8-content-grid--three">
-        {[...partialCommands, ...plannedCommands].map((item) => (
+        {evolvingCommands.map((item) => (
           <article class="autom8-standard-card">
-            <span class={statusClass[item.status]}>{statusLabel[item.status]}</span>
+            <span class={statusClass[item.status]}>
+              {statusLabel[item.status]}
+            </span>
             <h3><code>{item.command}</code></h3>
             <p>{item.summary}</p>
           </article>
@@ -159,95 +203,49 @@ const statusClass = {
     </div>
   </section>
 
-  <section id="modulos" class="site-page-section">
+  <section id="ajuda" class="site-page-section">
     <div class="site-page-section__inner">
       <div class="section-heading">
-        <p class="section-eyebrow text-blue-300">Módulos</p>
-        <h2>Módulos da suíte</h2>
-        <p>Cada módulo tem status explícito para evitar prometer funcionalidades ainda planejadas.</p>
+        <p class="section-eyebrow text-green-300">Ajuda</p>
+        <h2>Problemas comuns</h2>
+        <p>Verificações rápidas antes de abrir um relato.</p>
       </div>
 
       <div class="autom8-content-grid autom8-content-grid--three">
-        {documentation.modules.map((item) => (
-          <article class="autom8-standard-card autom8-standard-card--module">
-            <div class="module-card-top">
-              <span class={statusClass[item.status]}>{statusLabel[item.status]}</span>
-              <span class="module-command">{item.command}</span>
-            </div>
-            <h3>{item.name}</h3>
-            <p>{item.description}</p>
+        {documentation.troubleshooting.map((item) => (
+          <article class="autom8-standard-card">
+            <span class="autom8-card-kicker">solução</span>
+            <h3>{item.title}</h3>
+            <p>{item.solution}</p>
           </article>
         ))}
       </div>
     </div>
   </section>
 
-  <section id="variaveis" class="site-page-section">
+  <section id="repositorio" class="site-page-section">
     <div class="site-page-section__inner">
       <div class="section-heading">
-        <p class="section-eyebrow text-green-300">Variáveis</p>
-        <h2>Configuração por ambiente</h2>
-        <p>Essas variáveis controlam instalação, release, empacotamento e deploy.</p>
-      </div>
-
-      <div class="autom8-table-card">
-        <table class="autom8-data-table">
-          <thead>
-            <tr>
-              <th>Variável</th>
-              <th>Padrão</th>
-              <th>Escopo</th>
-              <th>Descrição</th>
-            </tr>
-          </thead>
-          <tbody>
-            {documentation.variables.map((item) => (
-              <tr>
-                <td><code>{item.name}</code></td>
-                <td><code>{item.default}</code></td>
-                <td>{item.scope}</td>
-                <td>{item.description}</td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
-    </div>
-  </section>
-
-  <section id="release" class="site-page-section">
-    <div class="site-page-section__inner">
-      <div class="section-heading">
-        <p class="section-eyebrow text-blue-300">Release estável</p>
-        <h2>Distribuição via GitHub Releases</h2>
-        <p>{documentation.releasePolicy.sitePackagePolicy}</p>
-      </div>
-
-      <div class="autom8-command-panel">
-        <div class="autom8-command-panel__header">
-          <span>latest package</span>
-          <strong>GitHub Releases</strong>
-        </div>
-        <pre><code>{documentation.releasePolicy.latestPackageUrl}</code></pre>
-      </div>
-    </div>
-  </section>
-
-  <section id="troubleshooting" class="site-page-section">
-    <div class="site-page-section__inner">
-      <div class="section-heading">
-        <p class="section-eyebrow text-green-300">Troubleshooting</p>
-        <h2>Problemas comuns</h2>
-        <p>Primeiros pontos de verificação quando algo não sair como esperado.</p>
+        <p class="section-eyebrow text-blue-300">Repositório</p>
+        <h2>Documentação técnica</h2>
+        <p>
+          Arquitetura, contribuição, segurança e operação ficam junto ao
+          código para acompanhar cada mudança.
+        </p>
       </div>
 
       <div class="autom8-content-grid autom8-content-grid--three">
-        {documentation.troubleshooting.map((item) => (
-          <article class="autom8-standard-card">
-            <span class="autom8-card-kicker">fix</span>
+        {repositoryDocs.map((item) => (
+          <a
+            class="autom8-standard-card"
+            href={item.href}
+            target="_blank"
+            rel="noreferrer"
+          >
+            <span class="autom8-card-kicker">GitHub</span>
             <h3>{item.title}</h3>
-            <p>{item.solution}</p>
-          </article>
+            <p>{item.description}</p>
+          </a>
         ))}
       </div>
     </div>

--- a/suite/docs/help.txt
+++ b/suite/docs/help.txt
@@ -1,6 +1,6 @@
 AutoM8 - Linux Management Suite
 
-AutoM8 é uma suíte local para preparar, diagnosticar, atualizar e manter ambientes Linux com visual terminal premium, catálogo de apps, logs e controle explícito do usuário.
+AutoM8 é uma CLI local para instalar aplicativos, aplicar perfis e executar manutenção Linux com confirmação, logs e modo de simulação.
 
 Uso:
   autom8


### PR DESCRIPTION
## O que mudou

- torna o README mais curto e voltado ao primeiro uso;
- consolida a documentação a partir da fonte canônica;
- simplifica a página pública de documentação;
- adiciona orientações de contribuição e segurança;
- separa documentação pública de detalhes internos de operação;
- atualiza os comandos de desenvolvimento para a estrutura atual.

## Impacto

- nenhuma mudança na versão da CLI;
- nenhuma nova release;
- nenhuma alteração funcional nos módulos;
- website precisa ser reconstruído após o merge.

## Validação

- `./scripts/sync-docs.sh`
- `./scripts/check.sh all`
- `git diff --check`