### PR TITLE
Comando de status do sistema

### DIFF
--- a/scripts/cli/check.sh
+++ b/scripts/cli/check.sh
@@ -152,8 +152,25 @@ if [[ "$plain_output" == *$'\033['* ]]; then
   error "A saída sem cores contém sequência ANSI."
 fi
 
-if "$cli_binary" status >/dev/null 2>&1; then
-  error "O comando ainda não implementado 'status' deveria falhar."
-fi
+log "Validando o comando status..."
+status_output="$("$cli_binary" status)"
+[[ "$status_output" == *"AutoM8 — status do sistema"* ]] ||
+  error "A saída humana do status é inválida."
 
-log "Fundação da CLI aprovada."
+status_json="$("$cli_binary" status --json)"
+jq -e '
+  (.hostname | type == "string" and length > 0) and
+  (.distribution.id | type == "string" and length > 0) and
+  (.distribution.name | type == "string" and length > 0) and
+  (.distribution.version | type == "string") and
+  (.kernel | type == "string" and length > 0) and
+  (.architecture | type == "string" and length > 0) and
+  ((.desktop == null) or (.desktop | type == "string")) and
+  (.uptime_seconds | type == "number" and . >= 0)
+' <<<"$status_json" >/dev/null ||
+  error "O contrato JSON do status é inválido."
+
+[[ "$status_json" != *"AutoM8 — status do sistema"* ]] ||
+  error "A saída JSON contém texto destinado a humanos."
+
+log "CLI e comando status aprovados."

--- a/scripts/cli/smoke-foundation.sh
+++ b/scripts/cli/smoke-foundation.sh
@@ -20,6 +20,7 @@ esac
 require_command awk
 require_command cargo
 require_command grep
+require_command jq
 require_command mktemp
 
 if [[ ! -r /etc/os-release ]]; then
@@ -71,8 +72,20 @@ if grep -Fq $'\033[' "${temporary_directory}/banner.txt"; then
   error "O banner sem cores contém sequência ANSI."
 fi
 
-if "$cli_binary" status >"${temporary_directory}/invalid.txt" 2>&1; then
-  error "O comando ainda não implementado 'status' deveria retornar falha."
-fi
+log "Validando o primeiro comando funcional..."
+"$cli_binary" status >"${temporary_directory}/status.txt"
+"$cli_binary" status --json >"${temporary_directory}/status.json"
+
+grep -Fq 'AutoM8 — status do sistema' "${temporary_directory}/status.txt" ||
+  error "Cabeçalho do status não encontrado."
+
+jq -e '
+  (.hostname | type == "string" and length > 0) and
+  (.distribution.id | type == "string" and length > 0) and
+  (.kernel | type == "string" and length > 0) and
+  (.architecture | type == "string" and length > 0) and
+  (.uptime_seconds | type == "number" and . >= 0)
+' "${temporary_directory}/status.json" >/dev/null ||
+  error "Contrato JSON do status é inválido."
 
 log "Smoke da fundação concluído em ${PRETTY_NAME:-$expected_distribution}."

--- a/suite/Cargo.lock
+++ b/suite/Cargo.lock
@@ -64,11 +64,15 @@ version = "0.3.0-alpha.1"
 dependencies = [
  "autom8-core",
  "clap",
+ "serde_json",
 ]
 
 [[package]]
 name = "autom8-core"
 version = "0.3.0-alpha.1"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "autom8-gnome"
@@ -516,6 +520,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
 name = "libadwaita"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -650,6 +660,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -667,6 +687,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.150"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -818,3 +851,9 @@ checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/suite/Cargo.toml
+++ b/suite/Cargo.toml
@@ -19,6 +19,8 @@ adw = { package = "libadwaita", version = "=0.9.2" }
 autom8-core = { path = "crates/autom8-core" }
 clap = { version = "=4.6.2", features = ["derive"] }
 gtk = { package = "gtk4", version = "=0.11.4" }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/suite/README.md
+++ b/suite/README.md
@@ -9,8 +9,14 @@ O workspace possui três pacotes:
 - `autom8-cli`: interface rápida para terminal;
 - `autom8-gnome`: aplicação nativa GTK 4/libadwaita.
 
-Nesta primeira etapa, a CLI implementa somente banner, `--help` e `--version`.
-A aplicação GNOME é apenas uma janela inicial, sem operações no sistema.
+A CLI implementa banner, `--help`, `--version` e o primeiro comando funcional:
+
+```bash
+autom8 status
+autom8 status --json
+```
+
+A aplicação GNOME permanece como janela inicial, sem operações no sistema.
 
 ## Metadados estáveis preservados
 

--- a/suite/apps/autom8-cli/Cargo.toml
+++ b/suite/apps/autom8-cli/Cargo.toml
@@ -15,6 +15,7 @@ path = "src/main.rs"
 [dependencies]
 autom8-core.workspace = true
 clap.workspace = true
+serde_json.workspace = true
 
 [lints]
 workspace = true

--- a/suite/apps/autom8-cli/src/cli.rs
+++ b/suite/apps/autom8-cli/src/cli.rs
@@ -1,4 +1,4 @@
-use clap::Parser;
+use clap::{Args, Parser, Subcommand};
 
 #[derive(Debug, Parser)]
 #[command(
@@ -11,13 +11,29 @@ pub struct Cli {
     /// Desativa cores ANSI na saída.
     #[arg(long, global = true)]
     pub no_color: bool,
+
+    #[command(subcommand)]
+    pub command: Option<Commands>,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum Commands {
+    /// Exibe informações do sistema sem realizar alterações.
+    Status(StatusArgs),
+}
+
+#[derive(Debug, Args)]
+pub struct StatusArgs {
+    /// Produz saída JSON para automação.
+    #[arg(long)]
+    pub json: bool,
 }
 
 #[cfg(test)]
 mod tests {
     use clap::{CommandFactory, Parser};
 
-    use super::Cli;
+    use super::{Cli, Commands};
 
     #[test]
     fn clap_definition_is_valid() {
@@ -30,5 +46,18 @@ mod tests {
 
         assert!(cli.is_ok());
         assert!(cli.is_ok_and(|parsed| parsed.no_color));
+    }
+
+    #[test]
+    fn status_json_is_parsed() {
+        let cli = Cli::try_parse_from(["autom8", "status", "--json"]);
+
+        assert!(matches!(
+            cli,
+            Ok(Cli {
+                command: Some(Commands::Status(arguments)),
+                ..
+            }) if arguments.json
+        ));
     }
 }

--- a/suite/apps/autom8-cli/src/main.rs
+++ b/suite/apps/autom8-cli/src/main.rs
@@ -5,8 +5,9 @@ use std::io::{self, Write};
 use std::process::ExitCode;
 
 use autom8_core::ProductInfo;
+use autom8_core::status::{StatusError, SystemStatus};
 use clap::Parser;
-use cli::Cli;
+use cli::{Cli, Commands, StatusArgs};
 
 fn write_home(cli: &Cli) -> io::Result<()> {
     let product = ProductInfo::current();
@@ -25,15 +26,90 @@ fn write_home(cli: &Cli) -> io::Result<()> {
     )
 }
 
+fn write_status(arguments: &StatusArgs) -> Result<(), StatusCommandError> {
+    let status = SystemStatus::collect()?;
+    let stdout = io::stdout();
+    let mut output = stdout.lock();
+
+    if arguments.json {
+        serde_json::to_writer_pretty(&mut output, &status)?;
+        writeln!(output)?;
+    } else {
+        writeln!(output, "AutoM8 — status do sistema")?;
+        writeln!(output, "Hostname: {}", status.hostname)?;
+        writeln!(
+            output,
+            "Distribuição: {} ({})",
+            status.distribution.name, status.distribution.id
+        )?;
+        writeln!(output, "Versão: {}", status.distribution.version)?;
+        writeln!(output, "Kernel: {}", status.kernel)?;
+        writeln!(output, "Arquitetura: {}", status.architecture)?;
+        writeln!(
+            output,
+            "Desktop: {}",
+            status.desktop.as_deref().unwrap_or("não detectado")
+        )?;
+        writeln!(output, "Uptime: {} segundos", status.uptime_seconds)?;
+    }
+
+    Ok(())
+}
+
+#[derive(Debug)]
+enum StatusCommandError {
+    Collection(StatusError),
+    Json(serde_json::Error),
+    Output(io::Error),
+}
+
+impl From<StatusError> for StatusCommandError {
+    fn from(error: StatusError) -> Self {
+        Self::Collection(error)
+    }
+}
+
+impl From<serde_json::Error> for StatusCommandError {
+    fn from(error: serde_json::Error) -> Self {
+        Self::Json(error)
+    }
+}
+
+impl From<io::Error> for StatusCommandError {
+    fn from(error: io::Error) -> Self {
+        Self::Output(error)
+    }
+}
+
 fn main() -> ExitCode {
     let cli = Cli::parse();
 
-    match write_home(&cli) {
-        Ok(()) => ExitCode::SUCCESS,
-        Err(error) if error.kind() == io::ErrorKind::BrokenPipe => ExitCode::SUCCESS,
-        Err(error) => {
-            eprintln!("autom8: falha ao escrever a saída: {error}");
-            ExitCode::FAILURE
-        }
+    match &cli.command {
+        None => match write_home(&cli) {
+            Ok(()) => ExitCode::SUCCESS,
+            Err(error) if error.kind() == io::ErrorKind::BrokenPipe => ExitCode::SUCCESS,
+            Err(error) => {
+                eprintln!("autom8: falha ao escrever a saída: {error}");
+                ExitCode::FAILURE
+            }
+        },
+        Some(Commands::Status(arguments)) => match write_status(arguments) {
+            Ok(()) => ExitCode::SUCCESS,
+            Err(StatusCommandError::Output(error)) if error.kind() == io::ErrorKind::BrokenPipe => {
+                ExitCode::SUCCESS
+            }
+            Err(StatusCommandError::Collection(error)) => {
+                eprintln!("autom8: não foi possível coletar o status: {error}");
+                ExitCode::FAILURE
+            }
+            Err(StatusCommandError::Json(error)) => {
+                eprintln!("autom8: não foi possível gerar o JSON: {error}");
+                ExitCode::FAILURE
+            }
+            Err(StatusCommandError::Output(error)) => {
+                eprintln!("autom8: falha ao escrever a saída: {error}");
+                ExitCode::FAILURE
+            }
+        },
     }
 }

--- a/suite/crates/autom8-core/Cargo.toml
+++ b/suite/crates/autom8-core/Cargo.toml
@@ -8,5 +8,8 @@ repository.workspace = true
 authors.workspace = true
 description = "Contratos compartilhados do AutoM8"
 
+[dependencies]
+serde.workspace = true
+
 [lints]
 workspace = true

--- a/suite/crates/autom8-core/src/lib.rs
+++ b/suite/crates/autom8-core/src/lib.rs
@@ -1,5 +1,7 @@
 #![forbid(unsafe_code)]
 
+pub mod status;
+
 /// Nome público do produto.
 pub const PRODUCT_NAME: &str = "AutoM8";
 

--- a/suite/crates/autom8-core/src/status.rs
+++ b/suite/crates/autom8-core/src/status.rs
@@ -1,0 +1,239 @@
+use std::env;
+use std::error::Error;
+use std::fmt;
+use std::fs;
+use std::io;
+use std::process::Command;
+
+use serde::Serialize;
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct Distribution {
+    pub id: String,
+    pub name: String,
+    pub version: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct SystemStatus {
+    pub hostname: String,
+    pub distribution: Distribution,
+    pub kernel: String,
+    pub architecture: String,
+    pub desktop: Option<String>,
+    pub uptime_seconds: u64,
+}
+
+#[derive(Debug)]
+pub enum StatusError {
+    ReadFile {
+        path: &'static str,
+        source: io::Error,
+    },
+    CommandFailed {
+        command: &'static str,
+    },
+    InvalidUptime,
+}
+
+impl fmt::Display for StatusError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::ReadFile { path, source } => {
+                write!(formatter, "não foi possível ler {path}: {source}")
+            }
+            Self::CommandFailed { command } => {
+                write!(
+                    formatter,
+                    "o comando '{command}' não retornou um valor válido"
+                )
+            }
+            Self::InvalidUptime => formatter.write_str("o conteúdo de /proc/uptime é inválido"),
+        }
+    }
+}
+
+impl Error for StatusError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::ReadFile { source, .. } => Some(source),
+            Self::CommandFailed { .. } | Self::InvalidUptime => None,
+        }
+    }
+}
+
+impl SystemStatus {
+    pub fn collect() -> Result<Self, StatusError> {
+        let os_release = read_file("/etc/os-release")?;
+        let hostname = read_file("/etc/hostname")?;
+        let uptime = read_file("/proc/uptime")?;
+
+        Ok(Self {
+            hostname: parse_hostname(&hostname),
+            distribution: parse_os_release(&os_release),
+            kernel: uname("-r", "uname -r")?,
+            architecture: uname("-m", "uname -m")?,
+            desktop: detect_desktop(),
+            uptime_seconds: parse_uptime(&uptime)?,
+        })
+    }
+}
+
+fn read_file(path: &'static str) -> Result<String, StatusError> {
+    fs::read_to_string(path).map_err(|source| StatusError::ReadFile { path, source })
+}
+
+fn uname(argument: &str, description: &'static str) -> Result<String, StatusError> {
+    let output =
+        Command::new("uname")
+            .arg(argument)
+            .output()
+            .map_err(|_| StatusError::CommandFailed {
+                command: description,
+            })?;
+
+    if !output.status.success() {
+        return Err(StatusError::CommandFailed {
+            command: description,
+        });
+    }
+
+    let value = String::from_utf8_lossy(&output.stdout).trim().to_owned();
+
+    if value.is_empty() {
+        return Err(StatusError::CommandFailed {
+            command: description,
+        });
+    }
+
+    Ok(value)
+}
+
+fn parse_hostname(contents: &str) -> String {
+    let hostname = contents.trim();
+
+    if hostname.is_empty() {
+        "desconhecido".to_owned()
+    } else {
+        hostname.to_owned()
+    }
+}
+
+fn parse_os_release(contents: &str) -> Distribution {
+    let value = |key: &str| {
+        contents
+            .lines()
+            .filter_map(|line| line.split_once('='))
+            .find(|(candidate, _)| *candidate == key)
+            .map(|(_, raw)| decode_os_release_value(raw))
+    };
+
+    let id = value("ID").unwrap_or_else(|| "unknown".to_owned());
+    let name = value("PRETTY_NAME")
+        .or_else(|| value("NAME"))
+        .unwrap_or_else(|| id.clone());
+    let version = value("VERSION_ID").unwrap_or_default();
+
+    Distribution { id, name, version }
+}
+
+fn decode_os_release_value(raw: &str) -> String {
+    let value = raw.trim();
+    let unquoted = if value.len() >= 2
+        && ((value.starts_with('"') && value.ends_with('"'))
+            || (value.starts_with('\'') && value.ends_with('\'')))
+    {
+        &value[1..value.len() - 1]
+    } else {
+        value
+    };
+
+    unquoted
+        .replace("\\\"", "\"")
+        .replace("\\'", "'")
+        .replace("\\\\", "\\")
+}
+
+fn detect_desktop() -> Option<String> {
+    env::var("XDG_CURRENT_DESKTOP")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .or_else(|| {
+            env::var("DESKTOP_SESSION")
+                .ok()
+                .filter(|value| !value.trim().is_empty())
+        })
+}
+
+fn parse_uptime(contents: &str) -> Result<u64, StatusError> {
+    let seconds = contents
+        .split_whitespace()
+        .next()
+        .ok_or(StatusError::InvalidUptime)?
+        .parse::<f64>()
+        .map_err(|_| StatusError::InvalidUptime)?;
+
+    if !seconds.is_finite() || seconds.is_sign_negative() {
+        return Err(StatusError::InvalidUptime);
+    }
+
+    Ok(seconds.floor() as u64)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{parse_hostname, parse_os_release, parse_uptime};
+
+    #[test]
+    fn parses_fedora_os_release() {
+        let distribution = parse_os_release(
+            "NAME=\"Fedora Linux\"\n\
+             VERSION_ID=42\n\
+             ID=fedora\n\
+             PRETTY_NAME=\"Fedora Linux 42 (Workstation Edition)\"\n",
+        );
+
+        assert_eq!(distribution.id, "fedora");
+        assert_eq!(distribution.name, "Fedora Linux 42 (Workstation Edition)");
+        assert_eq!(distribution.version, "42");
+    }
+
+    #[test]
+    fn parses_ubuntu_os_release() {
+        let distribution = parse_os_release(
+            "NAME=\"Ubuntu\"\n\
+             VERSION_ID=\"24.04\"\n\
+             ID=ubuntu\n\
+             PRETTY_NAME=\"Ubuntu 24.04 LTS\"\n",
+        );
+
+        assert_eq!(distribution.id, "ubuntu");
+        assert_eq!(distribution.name, "Ubuntu 24.04 LTS");
+        assert_eq!(distribution.version, "24.04");
+    }
+
+    #[test]
+    fn unknown_distribution_uses_safe_defaults() {
+        let distribution = parse_os_release("CUSTOM=value\n");
+
+        assert_eq!(distribution.id, "unknown");
+        assert_eq!(distribution.name, "unknown");
+        assert!(distribution.version.is_empty());
+    }
+
+    #[test]
+    fn empty_hostname_uses_safe_fallback() {
+        assert_eq!(parse_hostname(" \n"), "desconhecido");
+    }
+
+    #[test]
+    fn uptime_is_rounded_down() {
+        assert!(parse_uptime("12345.67 54321.00\n").is_ok_and(|uptime| uptime == 12_345));
+    }
+
+    #[test]
+    fn invalid_uptime_is_rejected() {
+        assert!(parse_uptime("not-a-number\n").is_err());
+        assert!(parse_uptime("-10.0 20.0\n").is_err());
+    }
+}


### PR DESCRIPTION
## Objetivo

Adicionar o primeiro comando funcional da nova CLI Rust do AutoM8.

## Alterações

- adiciona `autom8 status`;
- adiciona `autom8 status --json`;
- coleta informações do sistema sem solicitar privilégios;
- detecta hostname, distribuição, versão, kernel e arquitetura;
- detecta o ambiente desktop quando disponível;
- informa o uptime em segundos;
- mantém a coleta no `autom8-core` para reutilização por outras interfaces;
- trata distribuições desconhecidas sem panic;
- atualiza os smoke tests e o Quality Gate da CLI.

## Segurança

O comando é estritamente somente leitura:

- não utiliza `sudo`;
- não altera configurações;
- não instala ou remove pacotes;
- não grava relatórios;
- não realiza operações no sistema.

## Validação

- sintaxe Bash;
- ShellCheck;
- rustfmt;
- Clippy com warnings tratados como erro;
- testes de todo o workspace;
- testes para Ubuntu e Fedora;
- teste de distribuição desconhecida;
- validação da saída humana;
- validação do contrato JSON;
- Quality Gate local completo aprovado;
- Quality Gate remoto #29 aprovado.

## Fora do escopo

- interface GNOME funcional;
- instalador da versão 0.3;
- empacotamento;
- website;
- tag, release ou deploy.
